### PR TITLE
Better prefabs and components

### DIFF
--- a/src/@types/lib/phecs.d.ts
+++ b/src/@types/lib/phecs.d.ts
@@ -2,7 +2,7 @@ declare module Phecs {
   interface Entity {
     id: string;
     components: Component[];
-    getComponent<T extends Component>(component: T): T;
+    getComponent<T extends ComponentConstructor>(component: T): InstanceType<T>;
   }
 
   type EntityData = {

--- a/src/@types/lib/phecs.d.ts
+++ b/src/@types/lib/phecs.d.ts
@@ -22,6 +22,15 @@ declare module Phecs {
     new(scene: Phaser.Scene, data: EntityData, entity: Entity): Component;
   }
 
+  type Prefab = {
+    components: {
+      component: ComponentConstructor,
+      data?: {
+        [key: string]: any,
+      }
+    }[]
+  }
+
   interface System {
     start?(phEntities: any): void;
     stop?(phEntities: any): void;

--- a/src/@types/lib/phecs.d.ts
+++ b/src/@types/lib/phecs.d.ts
@@ -1,7 +1,8 @@
 declare module Phecs {
   interface Entity {
     id: string;
-    components: Component[]
+    components: Component[];
+    getComponent<T extends Component>(component: T): T;
   }
 
   type EntityData = {

--- a/src/@types/lib/phecs.d.ts
+++ b/src/@types/lib/phecs.d.ts
@@ -1,6 +1,7 @@
 declare module Phecs {
   interface Entity {
     id: string;
+    type: string;
     components: Component[];
     getComponent<T extends ComponentConstructor>(component: T): InstanceType<T>;
   }

--- a/src/@types/lib/phecs.d.ts
+++ b/src/@types/lib/phecs.d.ts
@@ -1,9 +1,7 @@
 declare module Phecs {
   interface Entity {
     id: string;
-    components: {
-      [tag: string]: Component
-    }
+    components: Component[]
   }
 
   type EntityData = {
@@ -22,13 +20,15 @@ declare module Phecs {
     new(scene: Phaser.Scene, data: EntityData, entity: Entity): Component;
   }
 
+  type PrefabComponentDefinition = {
+    component: ComponentConstructor,
+    data?: {
+      [key: string]: any,
+    }
+  }
+
   type Prefab = {
-    components: {
-      component: ComponentConstructor,
-      data?: {
-        [key: string]: any,
-      }
-    }[]
+    components: PrefabComponentDefinition[];
   }
 
   interface System {

--- a/src/@types/lib/phecs.d.ts
+++ b/src/@types/lib/phecs.d.ts
@@ -3,6 +3,7 @@ declare module Phecs {
     id: string;
     type: string;
     components: Component[];
+    hasComponent<T extends ComponentConstructor>(component: T): boolean;
     getComponent<T extends ComponentConstructor>(component: T): InstanceType<T>;
   }
 

--- a/src/components/adventurer-component.ts
+++ b/src/components/adventurer-component.ts
@@ -1,8 +1,6 @@
 type Controls = { [control: string]: Phaser.Input.Keyboard.Key };
 
 export class AdventurerComponent implements Phecs.Component {
-  public static tag: string = 'adventurer';
-
   public controls: Controls;
   public codes: { [code: string]: string };
 

--- a/src/components/arrow-component.ts
+++ b/src/components/arrow-component.ts
@@ -1,6 +1,4 @@
 export class ArrowComponent implements Phecs.Component {
-  public static tag: 'arrow';
-
   constructor() {}
 
   destroy(): void {

--- a/src/components/arrow-component.ts
+++ b/src/components/arrow-component.ts
@@ -1,0 +1,8 @@
+export class ArrowComponent implements Phecs.Component {
+  public static tag: 'arrow';
+
+  constructor() {}
+
+  destroy(): void {
+  }
+}

--- a/src/components/arrow-component.ts
+++ b/src/components/arrow-component.ts
@@ -1,6 +1,0 @@
-export class ArrowComponent implements Phecs.Component {
-  constructor() {}
-
-  destroy(): void {
-  }
-}

--- a/src/components/attachment-component.ts
+++ b/src/components/attachment-component.ts
@@ -1,8 +1,6 @@
 import { Attachment } from '../lib/attachment';
 
 export class AttachmentComponent implements Phecs.Component {
-  static tag = 'attachment';
-
   public attachments: Attachment[];
 
   private scene: Phaser.Scene;

--- a/src/components/bounds-component.ts
+++ b/src/components/bounds-component.ts
@@ -1,6 +1,4 @@
 export class BoundsComponent implements Phecs.Component {
-  static tag = 'bounds';
-
   public boundsFrames: Systems.HasBounds.Frame[];
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData) {

--- a/src/components/door-component.ts
+++ b/src/components/door-component.ts
@@ -1,6 +1,4 @@
 export class DoorComponent implements Phecs.Component {
-  public static tag: string = 'door';
-
   public toAreaKey: string;
   public toMarker: string;
 

--- a/src/components/enemy-component.ts
+++ b/src/components/enemy-component.ts
@@ -2,8 +2,6 @@ import { HealthComponent } from './health-component';
 import { PhiniteStateMachineComponent } from './phinite-state-machine-component';
 
 export class EnemyComponent implements Phecs.Component {
-  public static tag: string = 'enemy';
-
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {
     const healthComponent = entity.getComponent(HealthComponent);
     const phiniteStateMachine = entity.getComponent(PhiniteStateMachineComponent).phiniteStateMachine;

--- a/src/components/enemy-component.ts
+++ b/src/components/enemy-component.ts
@@ -5,8 +5,8 @@ export class EnemyComponent implements Phecs.Component {
   public static tag: string = 'enemy';
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {
-    const healthComponent = entity.components[HealthComponent.tag];
-    const phiniteStateMachine = entity.components[PhiniteStateMachineComponent.tag].phiniteStateMachine;
+    const healthComponent = entity.getComponent(HealthComponent);
+    const phiniteStateMachine = entity.getComponent(PhiniteStateMachineComponent).phiniteStateMachine;
 
     healthComponent.onDamage(() => {
       phiniteStateMachine.doTransition({ to: 'enemy-stun' });

--- a/src/components/health-component.ts
+++ b/src/components/health-component.ts
@@ -1,10 +1,13 @@
+type OnDamageListener = (newHealth: number) => void;
+type OnDeathListener = () => void;
+
 export class HealthComponent implements Phecs.Component {
   public static tag: string = 'health';
 
   private maxHealth: number;
   private currentHealth: number;
-  private onDeathListeners: (() => void)[];
-  private onDamageListeners: ((newHealth: number) => void)[];
+  private onDeathListeners: OnDeathListener[];
+  private onDamageListeners: OnDamageListener[];
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData) {
     this.maxHealth = data.maxHealth;
@@ -24,11 +27,11 @@ export class HealthComponent implements Phecs.Component {
     }
   }
 
-  onDamage(listener: () => void) {
+  onDamage(listener: OnDamageListener) {
     this.onDamageListeners.push(listener);
   }
 
-  onDeath(listener: () => void) {
+  onDeath(listener: OnDeathListener) {
     this.onDeathListeners.push(listener);
   }
 

--- a/src/components/health-component.ts
+++ b/src/components/health-component.ts
@@ -2,8 +2,6 @@ type OnDamageListener = (newHealth: number) => void;
 type OnDeathListener = () => void;
 
 export class HealthComponent implements Phecs.Component {
-  public static tag: string = 'health';
-
   private maxHealth: number;
   private currentHealth: number;
   private onDeathListeners: OnDeathListener[];

--- a/src/components/hitbox-component.ts
+++ b/src/components/hitbox-component.ts
@@ -2,8 +2,6 @@ import { AttachmentComponent } from './attachment-component';
 import { Attachment } from '../lib/attachment';
 
 export class HitboxComponent implements Phecs.Component {
-  public static tag: string = 'hitbox';
-
   public hitboxFrames: Systems.HasHitboxes.Frame[]
   public enabled: boolean;
 

--- a/src/components/hitbox-component.ts
+++ b/src/components/hitbox-component.ts
@@ -19,7 +19,7 @@ export class HitboxComponent implements Phecs.Component {
       .reduce((localMaxAttachmentCount, attachmentCount) => Math.max(localMaxAttachmentCount, attachmentCount), 0);
 
     for (let i = 0; i < maxAttachmentCount; i++) {
-      entity.components[AttachmentComponent.tag].createAttachment('hitbox', {
+      entity.getComponent(AttachmentComponent).createAttachment('hitbox', {
         offsetX: 0,
         offsetY: 0,
         width: 0,
@@ -35,7 +35,7 @@ export class HitboxComponent implements Phecs.Component {
   disable() {
     this.enabled = false;
 
-    this.entity.components[AttachmentComponent.tag]
+    this.entity.getComponent(AttachmentComponent)
       .getAttachmentsByType('hitbox').forEach((hitbox: Attachment) => {
         hitbox.disable();
     });

--- a/src/components/hurtbox-component.ts
+++ b/src/components/hurtbox-component.ts
@@ -19,7 +19,7 @@ export class HurtboxComponent implements Phecs.Component {
       .reduce((localMaxAttachmentCount, attachmentCount) => Math.max(localMaxAttachmentCount, attachmentCount), 0);
 
     for (let i = 0; i < maxAttachmentCount; i++) {
-      entity.components[AttachmentComponent.tag].createAttachment('hurtbox', {
+      entity.getComponent(AttachmentComponent).createAttachment('hurtbox', {
         offsetX: 0,
         offsetY: 0,
         width: 0,
@@ -35,7 +35,7 @@ export class HurtboxComponent implements Phecs.Component {
   disable() {
     this.enabled = false;
 
-    this.entity.components[AttachmentComponent.tag]
+    this.entity.getComponent(AttachmentComponent)
       .getAttachmentsByType('hurtbox').forEach((hurtbox: Attachment) => {
         hurtbox.disable();
     });

--- a/src/components/hurtbox-component.ts
+++ b/src/components/hurtbox-component.ts
@@ -2,8 +2,6 @@ import { AttachmentComponent } from './attachment-component';
 import { Attachment } from '../lib/attachment';
 
 export class HurtboxComponent implements Phecs.Component {
-  public static tag: string = 'hurtbox';
-
   public hurtboxFrames: Systems.HasHurtboxes.Frame[];
   public enabled: boolean;
 

--- a/src/components/indicator-component.ts
+++ b/src/components/indicator-component.ts
@@ -1,8 +1,6 @@
 import { SpriteComponent } from './sprite-component';
 
 export class IndicatorComponent implements Phecs.Component {
-  public static tag: string = 'indicator';
-
   public indicatorSprite: Phaser.GameObjects.Sprite;
   public showIndicator: () => void;
   public hideIndicator: () => void;

--- a/src/components/indicator-component.ts
+++ b/src/components/indicator-component.ts
@@ -9,7 +9,7 @@ export class IndicatorComponent implements Phecs.Component {
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {
     let { x, y } = data;
-    y = y - entity.components[SpriteComponent.tag].sprite.displayHeight - 20;
+    y = y - entity.getComponent(SpriteComponent).sprite.displayHeight - 20;
 
     const indicatorSprite = scene.add.sprite(x, y, 'indicator-down');
     indicatorSprite.setDepth(2);

--- a/src/components/interaction-circle-component.ts
+++ b/src/components/interaction-circle-component.ts
@@ -1,8 +1,6 @@
 import { InteractionTracker } from '../lib/interaction-tracker';
 
 export class InteractionCircleComponent implements Phecs.Component {
-  public static tag: string = 'interaction-circle';
-
   public interactionControl: string;
   public interactionCircle: Phaser.Geom.Circle;
   public interactionTracker: InteractionTracker;

--- a/src/components/invulnerability-component.ts
+++ b/src/components/invulnerability-component.ts
@@ -1,7 +1,6 @@
 import { SpriteComponent } from "./sprite-component";
 
 export class InvulnerabilityComponent implements Phecs.Component {
-  public static tag = 'invulnerability';
   public isInvulnerable: boolean;
 
   private scene: Phaser.Scene;

--- a/src/components/invulnerability-component.ts
+++ b/src/components/invulnerability-component.ts
@@ -10,7 +10,7 @@ export class InvulnerabilityComponent implements Phecs.Component {
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {
     this.scene = scene;
     this.isInvulnerable = false;
-    this.sprite = entity.components[SpriteComponent.tag].sprite;
+    this.sprite = entity.getComponent(SpriteComponent).sprite;
   }
 
   makeInvulnerable() {

--- a/src/components/phinite-state-machine-component.ts
+++ b/src/components/phinite-state-machine-component.ts
@@ -3,8 +3,6 @@ import { BaseScene } from '../scenes/base-scene';
 import { TransitionType } from '../lib/phinite-state-machine/transition-type';
 
 export class PhiniteStateMachineComponent implements Phecs.Component {
-  public static tag: string = 'phinite-state-machine';
-
   public phiniteStateMachine: PhiniteStateMachine<Phecs.Entity>;
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {

--- a/src/components/physics-body-component.ts
+++ b/src/components/physics-body-component.ts
@@ -1,8 +1,6 @@
 import { SpriteComponent } from './sprite-component';
 
 export class PhysicsBodyComponent implements Phecs.Component {
-  public static tag: string = 'physics-body';
-
   public body: Phaser.Physics.Arcade.Body;
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {

--- a/src/components/physics-body-component.ts
+++ b/src/components/physics-body-component.ts
@@ -6,16 +6,17 @@ export class PhysicsBodyComponent implements Phecs.Component {
   public body: Phaser.Physics.Arcade.Body;
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData, entity: Phecs.Entity) {
-    scene.physics.add.existing(entity.components[SpriteComponent.tag].sprite) as Phaser.Physics.Arcade.Sprite;
+    scene.physics.add.existing(entity.getComponent(SpriteComponent).sprite) as Phaser.Physics.Arcade.Sprite;
 
     // The sheep had a weird scaling issue where the body wasn't the same size as the sprite.
     // It was being set to the pre-scaled size instead.
     // So there's some code here that manually syncs it up.
-    const sprite = entity.components[SpriteComponent.tag].sprite;
-    sprite.body.setSize(sprite.width, sprite.height);
-    sprite.body.updateBounds();
-
+    const sprite = entity.getComponent(SpriteComponent).sprite;
     this.body = sprite.body as Phaser.Physics.Arcade.Body;
+
+    this.body.setSize(sprite.width, sprite.height);
+    this.body.updateBounds();
+
 
     if (data.maxVelocityX) {
       this.body.maxVelocity.x = data.maxVelocityX;

--- a/src/components/scene-component.ts
+++ b/src/components/scene-component.ts
@@ -1,0 +1,13 @@
+// This is a temporary component until PhiniteStateMachine states have access to the scene
+
+export class SceneComponent implements Phecs.Component {
+  public scene: Phaser.Scene;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  destroy() {
+    delete this.scene;
+  }
+}

--- a/src/components/shoots-arrows-component.ts
+++ b/src/components/shoots-arrows-component.ts
@@ -6,8 +6,6 @@ import { PhysicsBodyComponent } from './physics-body-component';
 const ARROW_POOL_COUNT = 3;
 
 export class ShootsArrowsComponent implements Phecs.Component {
-  public static tag: string = 'shoots-arrows';
-
   public shotPower: number;
   public shotChargeRate: number;
 

--- a/src/components/shoots-arrows-component.ts
+++ b/src/components/shoots-arrows-component.ts
@@ -27,8 +27,8 @@ export class ShootsArrowsComponent implements Phecs.Component {
 
     this.arrows = [];
     for (let i = 0; i < ARROW_POOL_COUNT; i++) {
-      const arrow = baseScene.phecs.phEntities.createPrefab('arrow', {}, entity.components[SpriteComponent.tag].sprite.depth, 0, 0);
-      arrow.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.doTransition({ to: 'arrow-disabled' });
+      const arrow = baseScene.phecs.phEntities.createPrefab('arrow', {}, entity.getComponent(SpriteComponent).sprite.depth, 0, 0);
+      arrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.doTransition({ to: 'arrow-disabled' });
       this.arrows.push(arrow);
     }
   }
@@ -36,27 +36,27 @@ export class ShootsArrowsComponent implements Phecs.Component {
   shootArrow() {
     const availableArrow = this.getAvailableArrow();
 
-    availableArrow.components[SpriteComponent.tag].sprite.x = this.entity.components[SpriteComponent.tag].sprite.x;
-    availableArrow.components[SpriteComponent.tag].sprite.y = this.entity.components[SpriteComponent.tag].sprite.y;
+    availableArrow.getComponent(SpriteComponent).sprite.x = this.entity.getComponent(SpriteComponent).sprite.x;
+    availableArrow.getComponent(SpriteComponent).sprite.y = this.entity.getComponent(SpriteComponent).sprite.y;
 
-    availableArrow.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.doTransition({ to: 'arrow-flying' });
+    availableArrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.doTransition({ to: 'arrow-flying' });
 
     let power = Phaser.Math.Clamp(this.shotPower, this.minShotPower, this.maxShotPower);
-    if (this.entity.components[SpriteComponent.tag].sprite.flipX) {
+    if (this.entity.getComponent(SpriteComponent).sprite.flipX) {
       power *= -1;
     }
 
-    availableArrow.components[PhysicsBodyComponent.tag].body.setVelocity(power, 0);
-    availableArrow.components[PhysicsBodyComponent.tag].body.setGravityY(-500); // entity gravity = world gravity + this
+    availableArrow.getComponent(PhysicsBodyComponent).body.setVelocity(power, 0);
+    availableArrow.getComponent(PhysicsBodyComponent).body.setGravityY(-500); // entity gravity = world gravity + this
 
     this.shotPower = this.minShotPower;
   }
 
   private getAvailableArrow() {
     const disabledArrows = this.arrows
-      .filter(arrow => arrow.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.currentState.id === 'arrow-disabled');
+      .filter(arrow => arrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.currentState.id === 'arrow-disabled');
     const hitArrows = this.arrows
-      .filter(arrow => arrow.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.currentState.id === 'arrow-hit')
+      .filter(arrow => arrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.currentState.id === 'arrow-hit')
 
     if (disabledArrows.length) {
       return disabledArrows[0];

--- a/src/components/sign-component.ts
+++ b/src/components/sign-component.ts
@@ -1,6 +1,4 @@
 export class SignComponent implements Phecs.Component {
-  public static tag: 'sign';
-
   constructor() {}
 
   destroy(): void {

--- a/src/components/sign-component.ts
+++ b/src/components/sign-component.ts
@@ -1,6 +1,0 @@
-export class SignComponent implements Phecs.Component {
-  constructor() {}
-
-  destroy(): void {
-  }
-}

--- a/src/components/sign-component.ts
+++ b/src/components/sign-component.ts
@@ -1,0 +1,8 @@
+export class SignComponent implements Phecs.Component {
+  public static tag: 'sign';
+
+  constructor() {}
+
+  destroy(): void {
+  }
+}

--- a/src/components/sprite-component.ts
+++ b/src/components/sprite-component.ts
@@ -1,6 +1,4 @@
 export class SpriteComponent implements Phecs.Component {
-  public static tag: string = 'sprite';
-
   public sprite: Phaser.GameObjects.Sprite;
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData) {

--- a/src/components/textbox-component.ts
+++ b/src/components/textbox-component.ts
@@ -1,10 +1,4 @@
-  type SignData = {
-    message: string;
-  }
-
 export class TextboxComponent implements Phecs.Component {
-  public static tag: string = 'textbox';
-
   public isTextboxShowing: boolean;
 
   private signs: Systems.SignSystem.SignData[];

--- a/src/components/zone-boundary-component.ts
+++ b/src/components/zone-boundary-component.ts
@@ -1,8 +1,6 @@
 import { BaseScene } from '../scenes/base-scene';
 
 export class ZoneBoundaryComponent implements Phecs.Component {
-  public static tag: string = 'zone-boundary';
-
   public zone: Phaser.Geom.Rectangle;
 
   constructor(scene: Phaser.Scene, data: Phecs.EntityData) {

--- a/src/entities/adventurer/prefab.ts
+++ b/src/entities/adventurer/prefab.ts
@@ -8,6 +8,7 @@ import { InteractionCircleComponent } from "../../components/interaction-circle-
 import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
 import { ShootsArrowsComponent } from "../../components/shoots-arrows-component";
 import { HealthComponent } from "../../components/health-component";
+import { InvulnerabilityComponent } from "../../components/invulnerability-component";
 
 export const adventurerPrefab: Phecs.Prefab = {
   components: [
@@ -70,6 +71,9 @@ export const adventurerPrefab: Phecs.Prefab = {
     },
     {
       component: HealthComponent,
+    },
+    {
+      component: InvulnerabilityComponent
     }
   ]
 }

--- a/src/entities/adventurer/prefab.ts
+++ b/src/entities/adventurer/prefab.ts
@@ -1,23 +1,75 @@
-export const adventurerPrefab = {
-  name: 'adventurer',
+import { SpriteComponent } from "../../components/sprite-component";
+import { PhysicsBodyComponent } from "../../components/physics-body-component";
+import { AdventurerComponent } from "../../components/adventurer-component";
+import { AttachmentComponent } from "../../components/attachment-component";
+import { HurtboxComponent } from "../../components/hurtbox-component";
+import { BoundsComponent } from "../../components/bounds-component";
+import { InteractionCircleComponent } from "../../components/interaction-circle-component";
+import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
+import { ShootsArrowsComponent } from "../../components/shoots-arrows-component";
+import { HealthComponent } from "../../components/health-component";
 
-  tags: "sprite,physics-body,adventurer,attachment,hurtbox,bounds,interaction-circle,phinite-state-machine,shoots-arrows,health,invulnerability",
-
-  attachmentDebug: false,
-
-  boundsKey: "adventurer-bounds",
-
-  texture: "adventurer-core",
-  frame: 0,
-  maxVelocityX: 350,
-
-  hurtboxesKey: "adventurer-hurtboxes",
-
-  interactionRadius: 30,
-  interactionDebug: false,
-
-  stateSet: "adventurer",
-  initialStateId: "adventurer-stand",
-
-  maxHealth: 5,
+export const adventurerPrefab: Phecs.Prefab = {
+  components: [
+    {
+      component: SpriteComponent,
+      data: {
+        texture: "adventurer-core",
+        frame: 0,
+      }
+    },
+    {
+      component: PhysicsBodyComponent,
+      data: {
+        maxVelocityX: 350,
+      }
+    },
+    {
+      component: AdventurerComponent,
+    },
+    {
+      component: AttachmentComponent,
+      data: {
+        attachmentDebug: false,
+      }
+    },
+    {
+      component: HurtboxComponent,
+      data: {
+        hurtboxesKey: "adventurer-hurtboxes",
+      }
+    },
+    {
+      component: BoundsComponent,
+      data: {
+        boundsKey: "adventurer-bounds",
+      }
+    },
+    {
+      component: InteractionCircleComponent,
+      data: {
+        interactionRadius: 30,
+        interactionDebug: false,
+      }
+    },
+    {
+      component: PhiniteStateMachineComponent,
+      data: {
+        stateSet: "adventurer",
+        initialStateId: "adventurer-stand",
+      }
+    },
+    {
+      component: ShootsArrowsComponent,
+    },
+    {
+      component: HealthComponent,
+      data: {
+        maxHealth: 5,
+      }
+    },
+    {
+      component: HealthComponent,
+    }
+  ]
 }

--- a/src/entities/adventurer/states/air-draw.ts
+++ b/src/entities/adventurer/states/air-draw.ts
@@ -9,48 +9,48 @@ import { ShootsArrowsComponent } from '../../../components/shoots-arrows-compone
 export const adventurerAirDraw: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge<Phecs.Entity>(baseAerial, {
   id: 'adventurer-air-draw',
   onEnter(entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-air-draw', true);
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-air-draw', true);
   },
   onUpdate(entity) {
-    entity.components[ShootsArrowsComponent.tag].shotPower += entity.components[ShootsArrowsComponent.tag].shotChargeRate;
+    entity.getComponent(ShootsArrowsComponent).shotPower += entity.getComponent(ShootsArrowsComponent).shotChargeRate;
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(entity) {
-        return entity.components[PhysicsBodyComponent.tag].body.blocked.down;
+        return entity.getComponent(PhysicsBodyComponent).body.blocked.down;
       },
       to: 'adventurer-stand-hold',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-air-shoot',
     },
     {
       type: TransitionType.Conditional,
       condition(entity) {
-        return !entity.components[SpriteComponent.tag].sprite.anims.isPlaying;
+        return !entity.getComponent(SpriteComponent).sprite.anims.isPlaying;
       },
       to: 'adventurer-air-hold'
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-air-draw',
       onTransition(entity) {
-        entity.components[SpriteComponent.tag].sprite.flipX = true;
+        entity.getComponent(SpriteComponent).sprite.flipX = true;
       }
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-air-draw',
       onTransition(entity) {
-        entity.components[SpriteComponent.tag].sprite.flipX = false;
+        entity.getComponent(SpriteComponent).sprite.flipX = false;
       }
     }
   ]

--- a/src/entities/adventurer/states/air-hold.ts
+++ b/src/entities/adventurer/states/air-hold.ts
@@ -9,41 +9,41 @@ import { ShootsArrowsComponent } from '../../../components/shoots-arrows-compone
 export const adventurerAirHold: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge<Phecs.Entity>(baseAerial, {
   id: 'adventurer-air-hold',
   onEnter(entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-air-hold', true);
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-air-hold', true);
   },
   onUpdate(entity) {
-    entity.components[ShootsArrowsComponent.tag].shotPower += entity.components[ShootsArrowsComponent.tag].shotChargeRate;
+    entity.getComponent(ShootsArrowsComponent).shotPower += entity.getComponent(ShootsArrowsComponent).shotChargeRate;
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(entity) {
-        return entity.components[PhysicsBodyComponent.tag].body.blocked.down;
+        return entity.getComponent(PhysicsBodyComponent).body.blocked.down;
       },
       to: 'adventurer-stand-hold',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-air-shoot',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-air-hold',
       onTransition(entity) {
-        entity.components[SpriteComponent.tag].sprite.flipX = true;
+        entity.getComponent(SpriteComponent).sprite.flipX = true;
       }
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-air-hold',
       onTransition(entity) {
-        entity.components[SpriteComponent.tag].sprite.flipX = false;
+        entity.getComponent(SpriteComponent).sprite.flipX = false;
       }
     }
   ]

--- a/src/entities/adventurer/states/air-shoot.ts
+++ b/src/entities/adventurer/states/air-shoot.ts
@@ -8,30 +8,30 @@ import { ShootsArrowsComponent } from '../../../components/shoots-arrows-compone
 export const adventurerAirShoot: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge<Phecs.Entity>(baseAerial, {
   id: 'adventurer-air-shoot',
   onEnter(entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-air-shoot');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-air-shoot');
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(entity: Phecs.Entity) {
-        return entity.components[PhysicsBodyComponent.tag].body.blocked.down;
+        return entity.getComponent(PhysicsBodyComponent).body.blocked.down;
       },
       to: 'adventurer-stand-shoot',
     },
     {
       type: TransitionType.Conditional,
       condition(entity: Phecs.Entity) {
-        return !entity.components[SpriteComponent.tag].sprite.anims.isPlaying;
+        return !entity.getComponent(SpriteComponent).sprite.anims.isPlaying;
       },
       to(entity) {
-        if (entity.components[PhysicsBodyComponent.tag].body.velocity.y < 0) {
+        if (entity.getComponent(PhysicsBodyComponent).body.velocity.y < 0) {
           return 'adventurer-jump';
         } else {
           return 'adventurer-fall';
         }
       },
       onTransition(entity) {
-        entity.components[ShootsArrowsComponent.tag].shootArrow();
+        entity.getComponent(ShootsArrowsComponent).shootArrow();
       }
     }
   ]

--- a/src/entities/adventurer/states/base-aerial.ts
+++ b/src/entities/adventurer/states/base-aerial.ts
@@ -3,8 +3,8 @@ import { PhysicsBodyComponent } from '../../../components/physics-body-component
 import { AdventurerComponent } from '../../../components/adventurer-component';
 
 function applyAirControls(entity: Phecs.Entity, targetVelocity: number) {
-  const body = entity.components[PhysicsBodyComponent.tag].body;
-  const controls = entity.components[AdventurerComponent.tag].controls;
+  const body = entity.getComponent(PhysicsBodyComponent).body;
+  const controls = entity.getComponent(AdventurerComponent).controls;
 
   if (controls.left.isDown && body.velocity.x > targetVelocity) {
     body.acceleration.x = -1 * movementAttributes.aerialHorizontalAcceleration;
@@ -14,7 +14,7 @@ function applyAirControls(entity: Phecs.Entity, targetVelocity: number) {
 }
 
 function applyAirFriction(entity: Phecs.Entity) {
-  const body = entity.components[PhysicsBodyComponent.tag].body;
+  const body = entity.getComponent(PhysicsBodyComponent).body;
 
   if (body.velocity.x > 0) {
     body.acceleration.x = -1 * movementAttributes.aerialHorizontalFrictionAcceleration;
@@ -27,8 +27,8 @@ function applyAirFriction(entity: Phecs.Entity) {
 
 export const baseAerial: Partial<PhiniteStateMachine.States.State<Phecs.Entity>> = {
   onUpdate(entity: Phecs.Entity, data: PhiniteStateMachine.States.StateData) {
-    const body = entity.components[PhysicsBodyComponent.tag].body;
-    const controls = entity.components[AdventurerComponent.tag].controls;
+    const body = entity.getComponent(PhysicsBodyComponent).body;
+    const controls = entity.getComponent(AdventurerComponent).controls;
     const controlsAreDown = controls.left.isDown || controls.right.isDown;
 
     if (controlsAreDown) {

--- a/src/entities/adventurer/states/base-crouch.ts
+++ b/src/entities/adventurer/states/base-crouch.ts
@@ -6,15 +6,15 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 
 export const baseCrouch: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseIdle, {
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-crouch');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-crouch');
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.down,
+      key: entity => entity.getComponent(AdventurerComponent).codes.down,
       to: (entity: Phecs.Entity) => {
-        const controls = entity.components[AdventurerComponent.tag].controls;
+        const controls = entity.getComponent(AdventurerComponent).controls;
 
         if (controls.left.isDown) {
           return 'adventurer-run-left';

--- a/src/entities/adventurer/states/base-fall.ts
+++ b/src/entities/adventurer/states/base-fall.ts
@@ -9,25 +9,25 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 
 export const baseFall: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseAerial, {
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-fall');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-fall');
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-air-draw',
     },
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return entity.components[PhysicsBodyComponent.tag].body.blocked.down;
+        return entity.getComponent(PhysicsBodyComponent).body.blocked.down;
       },
       to(entity: Phecs.Entity) {
-        const controls = entity.components[AdventurerComponent.tag].controls;
+        const controls = entity.getComponent(AdventurerComponent).controls;
 
         if (controls.down.isDown) {
-          if (Math.abs(entity.components[PhysicsBodyComponent.tag].body.velocity.x) < movementAttributes.slideVelocityThreshold) {
+          if (Math.abs(entity.getComponent(PhysicsBodyComponent).body.velocity.x) < movementAttributes.slideVelocityThreshold) {
             return 'adventurer-crouch';
           } else {
             return 'adventurer-slide';

--- a/src/entities/adventurer/states/base-ground.ts
+++ b/src/entities/adventurer/states/base-ground.ts
@@ -6,14 +6,14 @@ export const baseGround: Partial<PhiniteStateMachine.States.State<Phecs.Entity>>
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return !entity.components[PhysicsBodyComponent.tag].body.blocked.down;
+        return !entity.getComponent(PhysicsBodyComponent).body.blocked.down;
       },
       to: (entity: Phecs.Entity) => {
-        entity.components[PhysicsBodyComponent.tag].body.velocity.y = 100;
+        entity.getComponent(PhysicsBodyComponent).body.velocity.y = 100;
 
-        if (entity.components[PhysicsBodyComponent.tag].body.velocity.x > 0) {
+        if (entity.getComponent(PhysicsBodyComponent).body.velocity.x > 0) {
           return 'adventurer-fall-right';
-        } else if (entity.components[PhysicsBodyComponent.tag].body.velocity.x < 0) {
+        } else if (entity.getComponent(PhysicsBodyComponent).body.velocity.x < 0) {
           return 'adventurer-fall-left';
         } else {
           return 'adventurer-fall';

--- a/src/entities/adventurer/states/base-idle.ts
+++ b/src/entities/adventurer/states/base-idle.ts
@@ -5,13 +5,13 @@ import { StateMerge } from '../../../lib/phinite-state-machine/state-merge';
 import { PhysicsBodyComponent } from '../../../components/physics-body-component';
 
 function decelerate(entity: Phecs.Entity) {
-  entity.components[PhysicsBodyComponent.tag].body.acceleration.x = entity.components[PhysicsBodyComponent.tag].body.velocity.x < 0 ? movementAttributes.horizontalDeceleration : -movementAttributes.horizontalDeceleration;
+  entity.getComponent(PhysicsBodyComponent).body.acceleration.x = entity.getComponent(PhysicsBodyComponent).body.velocity.x < 0 ? movementAttributes.horizontalDeceleration : -movementAttributes.horizontalDeceleration;
 }
 
 function haltMovementWithinThreshold(entity: Phecs.Entity) {
-  if (Phaser.Math.Within(entity.components[PhysicsBodyComponent.tag].body.velocity.x, 0, 100)) {
-    entity.components[PhysicsBodyComponent.tag].body.acceleration.x = 0;
-    entity.components[PhysicsBodyComponent.tag].body.velocity.x = 0;
+  if (Phaser.Math.Within(entity.getComponent(PhysicsBodyComponent).body.velocity.x, 0, 100)) {
+    entity.getComponent(PhysicsBodyComponent).body.acceleration.x = 0;
+    entity.getComponent(PhysicsBodyComponent).body.velocity.x = 0;
   }
 }
 

--- a/src/entities/adventurer/states/base-jump.ts
+++ b/src/entities/adventurer/states/base-jump.ts
@@ -6,13 +6,13 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 
 export const baseJump: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge<Phecs.Entity>(baseAerial, {
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-jump-rise');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-jump-rise');
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-air-draw',
     },
   ]

--- a/src/entities/adventurer/states/base-run.ts
+++ b/src/entities/adventurer/states/base-run.ts
@@ -9,22 +9,22 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 
 export const baseRun: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseGround, {
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = false;
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-run');
+    entity.getComponent(SpriteComponent).sprite.flipX = false;
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-run');
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-stand-draw',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.down,
+      key: entity => entity.getComponent(AdventurerComponent).codes.down,
       to: (entity: Phecs.Entity) => {
-        if (Math.abs(entity.components[PhysicsBodyComponent.tag].body.velocity.x) < movementAttributes.slideVelocityThreshold) {
+        if (Math.abs(entity.getComponent(PhysicsBodyComponent).body.velocity.x) < movementAttributes.slideVelocityThreshold) {
           return 'adventurer-crouch';
         } else {
           return 'adventurer-slide';
@@ -34,7 +34,7 @@ export const baseRun: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerg
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.up,
+      key: entity => entity.getComponent(AdventurerComponent).codes.up,
       to: 'adventurer-jump-prep',
     }
   ]
@@ -42,9 +42,9 @@ export const baseRun: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerg
 
 export function startRunning(entity: Phecs.Entity, direction: "left" | "right") {
   if (direction === "left") {
-    entity.components[PhysicsBodyComponent.tag].body.acceleration.x = -movementAttributes.horizontalAcceleration;
+    entity.getComponent(PhysicsBodyComponent).body.acceleration.x = -movementAttributes.horizontalAcceleration;
   } else if (direction === "right") {
-    entity.components[PhysicsBodyComponent.tag].body.acceleration.x = movementAttributes.horizontalAcceleration;
+    entity.getComponent(PhysicsBodyComponent).body.acceleration.x = movementAttributes.horizontalAcceleration;
   }
 
   boostTurnaroundVelocity(entity);
@@ -52,7 +52,7 @@ export function startRunning(entity: Phecs.Entity, direction: "left" | "right") 
 
 
 function boostTurnaroundVelocity(entity: Phecs.Entity) {
-  if (!Phaser.Math.Within(entity.components[PhysicsBodyComponent.tag].body.velocity.x, 0, 5)) {
-    entity.components[PhysicsBodyComponent.tag].body.velocity.x += entity.components[PhysicsBodyComponent.tag].body.velocity.x * 0.5 * -1;
+  if (!Phaser.Math.Within(entity.getComponent(PhysicsBodyComponent).body.velocity.x, 0, 5)) {
+    entity.getComponent(PhysicsBodyComponent).body.velocity.x += entity.getComponent(PhysicsBodyComponent).body.velocity.x * 0.5 * -1;
   }
 }

--- a/src/entities/adventurer/states/crouch-left.ts
+++ b/src/entities/adventurer/states/crouch-left.ts
@@ -7,13 +7,13 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerCrouchLeft: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseCrouch, {
   id: 'adventurer-crouch-left',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = true;
+    entity.getComponent(SpriteComponent).sprite.flipX = true;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-crouch-right'
     }
   ]

--- a/src/entities/adventurer/states/crouch-right.ts
+++ b/src/entities/adventurer/states/crouch-right.ts
@@ -7,13 +7,13 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerCrouchRight: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseCrouch, {
   id: 'adventurer-crouch-right',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = false;
+    entity.getComponent(SpriteComponent).sprite.flipX = false;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-crouch-left'
     }
   ]

--- a/src/entities/adventurer/states/crouch.ts
+++ b/src/entities/adventurer/states/crouch.ts
@@ -9,13 +9,13 @@ export const adventurerCrouch: PhiniteStateMachine.States.State<Phecs.Entity> = 
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-crouch-left'
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-crouch-right'
     }
   ]

--- a/src/entities/adventurer/states/fall-left.ts
+++ b/src/entities/adventurer/states/fall-left.ts
@@ -12,13 +12,13 @@ export const adventurerFallLeft: PhiniteStateMachine.States.State<Phecs.Entity> 
     targetAerialHorizontalVelocity: movementAttributes.aerialMaxHorizontalVelocity * -1,
   },
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = true;
+    entity.getComponent(SpriteComponent).sprite.flipX = true;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-fall-right',
     }
   ]

--- a/src/entities/adventurer/states/fall-right.ts
+++ b/src/entities/adventurer/states/fall-right.ts
@@ -12,13 +12,13 @@ export const adventurerFallRight: PhiniteStateMachine.States.State<Phecs.Entity>
     targetAerialHorizontalVelocity: movementAttributes.aerialMaxHorizontalVelocity,
   },
   onEnter(entity: Phecs.Entity, data: PhiniteStateMachine.States.StateData) {
-    entity.components[SpriteComponent.tag].sprite.flipX = false;
+    entity.getComponent(SpriteComponent).sprite.flipX = false;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-fall-left',
     }
   ]

--- a/src/entities/adventurer/states/fall.ts
+++ b/src/entities/adventurer/states/fall.ts
@@ -12,13 +12,13 @@ export const adventurerFall: PhiniteStateMachine.States.State<Phecs.Entity> = St
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-fall-left',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-fall-right',
     }
   ],

--- a/src/entities/adventurer/states/jump-left.ts
+++ b/src/entities/adventurer/states/jump-left.ts
@@ -12,19 +12,19 @@ export const adventurerJumpLeft: PhiniteStateMachine.States.State<Phecs.Entity> 
     targetAerialHorizontalVelocity: movementAttributes.aerialMaxHorizontalVelocity * -1,
   },
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = true;
+    entity.getComponent(SpriteComponent).sprite.flipX = true;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-jump-right',
     },
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return entity.components[PhysicsBodyComponent.tag].body.velocity.y > 0;
+        return entity.getComponent(PhysicsBodyComponent).body.velocity.y > 0;
       },
       to: 'adventurer-fall-left',
     }

--- a/src/entities/adventurer/states/jump-prep.ts
+++ b/src/entities/adventurer/states/jump-prep.ts
@@ -7,36 +7,36 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerJumpPrep: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'adventurer-jump-prep',
   onEnter(entity: Phecs.Entity) {
-    entity.components[PhysicsBodyComponent.tag].body.acceleration.x = 0;
+    entity.getComponent(PhysicsBodyComponent).body.acceleration.x = 0;
 
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-jump-prep');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-jump-prep');
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return !entity.components[SpriteComponent.tag].sprite.anims.isPlaying;
+        return !entity.getComponent(SpriteComponent).sprite.anims.isPlaying;
       },
       to: (entity: Phecs.Entity) => {
-        const controls = entity.components[AdventurerComponent.tag].controls;
+        const controls = entity.getComponent(AdventurerComponent).controls;
 
         if (controls.right.isDown) {
           return 'adventurer-jump-right';
         } else if (controls.left.isDown) {
           return 'adventurer-jump-left';
-        } else if (entity.components[PhysicsBodyComponent.tag].body.velocity.x > 0) {
+        } else if (entity.getComponent(PhysicsBodyComponent).body.velocity.x > 0) {
           return 'adventurer-jump-right';
-        } else if (entity.components[PhysicsBodyComponent.tag].body.velocity.x < 0) {
+        } else if (entity.getComponent(PhysicsBodyComponent).body.velocity.x < 0) {
           return 'adventurer-jump-left';
         } else {
           return 'adventurer-jump';
         }
       },
       onTransition: (entity: Phecs.Entity) => {
-        if (entity.components[AdventurerComponent.tag].controls.up.isDown) {
-          entity.components[PhysicsBodyComponent.tag].body.velocity.y = movementAttributes.jumpVelocity;
+        if (entity.getComponent(AdventurerComponent).controls.up.isDown) {
+          entity.getComponent(PhysicsBodyComponent).body.velocity.y = movementAttributes.jumpVelocity;
         } else {
-          entity.components[PhysicsBodyComponent.tag].body.velocity.y = movementAttributes.shortJumpVelocity;
+          entity.getComponent(PhysicsBodyComponent).body.velocity.y = movementAttributes.shortJumpVelocity;
         }
       },
     }

--- a/src/entities/adventurer/states/jump-right.ts
+++ b/src/entities/adventurer/states/jump-right.ts
@@ -12,19 +12,19 @@ export const adventurerJumpRight: PhiniteStateMachine.States.State<Phecs.Entity>
     targetAerialHorizontalVelocity: movementAttributes.aerialMaxHorizontalVelocity,
   },
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = false;
+    entity.getComponent(SpriteComponent).sprite.flipX = false;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-jump-left',
     },
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return entity.components[PhysicsBodyComponent.tag].body.velocity.y > 0;
+        return entity.getComponent(PhysicsBodyComponent).body.velocity.y > 0;
       },
       to: 'adventurer-fall-right',
     }

--- a/src/entities/adventurer/states/jump.ts
+++ b/src/entities/adventurer/states/jump.ts
@@ -13,19 +13,19 @@ export const adventurerJump: PhiniteStateMachine.States.State<Phecs.Entity> = St
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-jump-left',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-jump-right',
     },
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return entity.components[PhysicsBodyComponent.tag].body.velocity.y > 1;
+        return entity.getComponent(PhysicsBodyComponent).body.velocity.y > 1;
       },
       to: 'adventurer-fall'
     }

--- a/src/entities/adventurer/states/run-left.ts
+++ b/src/entities/adventurer/states/run-left.ts
@@ -7,8 +7,8 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerRunLeft: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseRun, {
   id: 'adventurer-run-left',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = true;
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-run');
+    entity.getComponent(SpriteComponent).sprite.flipX = true;
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-run');
 
     startRunning(entity, "left");
   },
@@ -16,13 +16,13 @@ export const adventurerRunLeft: PhiniteStateMachine.States.State<Phecs.Entity> =
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-stand',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-run-right',
     },
   ]

--- a/src/entities/adventurer/states/run-right.ts
+++ b/src/entities/adventurer/states/run-right.ts
@@ -7,8 +7,8 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerRunRight: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseRun, {
   id: 'adventurer-run-right',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.flipX = false;
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-run');
+    entity.getComponent(SpriteComponent).sprite.flipX = false;
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-run');
 
     startRunning(entity, "right");
   },
@@ -16,13 +16,13 @@ export const adventurerRunRight: PhiniteStateMachine.States.State<Phecs.Entity> 
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-stand',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-run-left',
     },
   ]

--- a/src/entities/adventurer/states/slide.ts
+++ b/src/entities/adventurer/states/slide.ts
@@ -9,27 +9,27 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerSlide: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseGround, {
   id: 'adventurer-slide',
   onEnter(adventurer: Phecs.Entity) {
-    adventurer.components[SpriteComponent.tag].sprite.anims.play('adventurer-slide')
+    adventurer.getComponent(SpriteComponent).sprite.anims.play('adventurer-slide')
 
-    if (adventurer.components[PhysicsBodyComponent.tag].body.velocity.x > 0) {
-      adventurer.components[PhysicsBodyComponent.tag].body.acceleration.x = -1 * movementAttributes.slideDeceleration;
+    if (adventurer.getComponent(PhysicsBodyComponent).body.velocity.x > 0) {
+      adventurer.getComponent(PhysicsBodyComponent).body.acceleration.x = -1 * movementAttributes.slideDeceleration;
     } else {
-      adventurer.components[PhysicsBodyComponent.tag].body.acceleration.x = movementAttributes.slideDeceleration;
+      adventurer.getComponent(PhysicsBodyComponent).body.acceleration.x = movementAttributes.slideDeceleration;
     }
   },
   onUpdate(entity: Phecs.Entity) {
-    if(Phaser.Math.Within(entity.components[PhysicsBodyComponent.tag].body.velocity.x, 0, 5)) {
-      entity.components[PhysicsBodyComponent.tag].body.acceleration.x = 0;
+    if(Phaser.Math.Within(entity.getComponent(PhysicsBodyComponent).body.velocity.x, 0, 5)) {
+      entity.getComponent(PhysicsBodyComponent).body.acceleration.x = 0;
     }
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition: (entity: Phecs.Entity) => {
-        return !entity.components[SpriteComponent.tag].sprite.anims.isPlaying;
+        return !entity.getComponent(SpriteComponent).sprite.anims.isPlaying;
       },
       to: (entity: Phecs.Entity) => {
-        const controls = entity.components[AdventurerComponent.tag].controls;
+        const controls = entity.getComponent(AdventurerComponent).controls;
 
         if (controls.left.isDown) {
           return 'adventurer-run-left';
@@ -45,7 +45,7 @@ export const adventurerSlide: PhiniteStateMachine.States.State<Phecs.Entity> = S
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.up,
+      key: entity => entity.getComponent(AdventurerComponent).codes.up,
       to: 'adventurer-jump-prep',
     }
   ],

--- a/src/entities/adventurer/states/stand-draw.ts
+++ b/src/entities/adventurer/states/stand-draw.ts
@@ -8,41 +8,41 @@ import { ShootsArrowsComponent } from '../../../components/shoots-arrows-compone
 export const adventurerStandDraw: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseIdle, {
   id: 'adventurer-stand-draw',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-stand-draw', true);
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-stand-draw', true);
   },
   onUpdate(entity) {
-    entity.components[ShootsArrowsComponent.tag].shotPower += entity.components[ShootsArrowsComponent.tag].shotChargeRate;
+    entity.getComponent(ShootsArrowsComponent).shotPower += entity.getComponent(ShootsArrowsComponent).shotChargeRate;
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(entity: Phecs.Entity) {
-        return !entity.components[SpriteComponent.tag].sprite.anims.isPlaying;
+        return !entity.getComponent(SpriteComponent).sprite.anims.isPlaying;
       },
       to: 'adventurer-stand-hold'
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-stand-shoot',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-stand-draw',
       onTransition(entity) {
-        entity.components[SpriteComponent.tag].sprite.flipX = true;
+        entity.getComponent(SpriteComponent).sprite.flipX = true;
       }
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-stand-draw',
       onTransition(entity) {
-        entity.components[SpriteComponent.tag].sprite.flipX = false;
+        entity.getComponent(SpriteComponent).sprite.flipX = false;
       }
     }
   ]

--- a/src/entities/adventurer/states/stand-hold.ts
+++ b/src/entities/adventurer/states/stand-hold.ts
@@ -8,34 +8,34 @@ import { ShootsArrowsComponent } from '../../../components/shoots-arrows-compone
 export const adventurerStandHold: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseIdle, {
   id: 'adventurer-stand-hold',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-stand-hold', true);
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-stand-hold', true);
   },
   onUpdate(entity) {
-    entity.components[ShootsArrowsComponent.tag].shotPower += entity.components[ShootsArrowsComponent.tag].shotChargeRate;
+    entity.getComponent(ShootsArrowsComponent).shotPower += entity.getComponent(ShootsArrowsComponent).shotChargeRate;
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_UP,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-stand-shoot',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-stand-hold',
       onTransition: (entity) => {
-        entity.components[SpriteComponent.tag].sprite.flipX = true;
+        entity.getComponent(SpriteComponent).sprite.flipX = true;
       }
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-stand-hold',
       onTransition: (entity) => {
-        entity.components[SpriteComponent.tag].sprite.flipX = false;
+        entity.getComponent(SpriteComponent).sprite.flipX = false;
       }
     }
   ]

--- a/src/entities/adventurer/states/stand-shoot.ts
+++ b/src/entities/adventurer/states/stand-shoot.ts
@@ -8,19 +8,19 @@ import { ShootsArrowsComponent } from '../../../components/shoots-arrows-compone
 export const adventurerStandShoot: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseIdle, {
   id: 'adventurer-stand-shoot',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-stand-shoot');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-stand-shoot');
   },
   onLeave(entity) {
-    entity.components[ShootsArrowsComponent.tag].shootArrow();
+    entity.getComponent(ShootsArrowsComponent).shootArrow();
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(entity: Phecs.Entity) {
-        return !entity.components[SpriteComponent.tag].sprite.anims.isPlaying;
+        return !entity.getComponent(SpriteComponent).sprite.anims.isPlaying;
       },
       to(entity) {
-        const controls = entity.components[AdventurerComponent.tag].controls;
+        const controls = entity.getComponent(AdventurerComponent).controls;
 
         if (controls.right.isDown) {
           return 'adventurer-run-right';

--- a/src/entities/adventurer/states/stand.ts
+++ b/src/entities/adventurer/states/stand.ts
@@ -7,37 +7,37 @@ import { AdventurerComponent } from '../../../components/adventurer-component';
 export const adventurerStand: PhiniteStateMachine.States.State<Phecs.Entity> = StateMerge(baseIdle, {
   id: 'adventurer-stand',
   onEnter(entity: Phecs.Entity) {
-    entity.components[SpriteComponent.tag].sprite.anims.play('adventurer-stand');
+    entity.getComponent(SpriteComponent).sprite.anims.play('adventurer-stand');
   },
   transitions: [
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.right,
+      key: entity => entity.getComponent(AdventurerComponent).codes.right,
       to: 'adventurer-run-right',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.left,
+      key: entity => entity.getComponent(AdventurerComponent).codes.left,
       to: 'adventurer-run-left',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.down,
+      key: entity => entity.getComponent(AdventurerComponent).codes.down,
       to: 'adventurer-crouch',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.up,
+      key: entity => entity.getComponent(AdventurerComponent).codes.up,
       to: 'adventurer-jump-prep',
     },
     {
       type: TransitionType.Input,
       event: Phaser.Input.Keyboard.Events.ANY_KEY_DOWN,
-      key: entity => entity.components[AdventurerComponent.tag].codes.attack,
+      key: entity => entity.getComponent(AdventurerComponent).codes.attack,
       to: 'adventurer-stand-draw'
     }
   ],

--- a/src/entities/arrow/prefab.ts
+++ b/src/entities/arrow/prefab.ts
@@ -4,7 +4,6 @@ import { AttachmentComponent } from "../../components/attachment-component";
 import { HitboxComponent } from "../../components/hitbox-component";
 import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
 import { BoundsComponent } from "../../components/bounds-component";
-import { ArrowComponent } from "../../components/arrow-component";
 
 export const arrowPrefab: Phecs.Prefab = {
   components: [
@@ -43,8 +42,5 @@ export const arrowPrefab: Phecs.Prefab = {
         boundsKey: 'arrow-bounds',
       }
     },
-    {
-      component: ArrowComponent
-    }
   ]
 };

--- a/src/entities/arrow/prefab.ts
+++ b/src/entities/arrow/prefab.ts
@@ -1,17 +1,46 @@
-export const arrowPrefab = {
-  name: 'arrow',
+import { SpriteComponent } from "../../components/sprite-component";
+import { PhysicsBodyComponent } from "../../components/physics-body-component";
+import { AttachmentComponent } from "../../components/attachment-component";
+import { HitboxComponent } from "../../components/hitbox-component";
+import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
+import { BoundsComponent } from "../../components/bounds-component";
 
-  tags: 'sprite,physics-body,attachment,hitbox,phinite-state-machine,bounds',
-
-  texture: 'arrow',
-  frame: 0,
-
-  stateSet: 'arrow',
-  initialStateId: 'arrow-disabled',
-
-  boundsKey: 'arrow-bounds',
-
-  hitboxesKey: 'arrow-hitboxes',
-
-  attachmentDebug: false,
+export const arrowPrefab: Phecs.Prefab = {
+  components: [
+    {
+      component: SpriteComponent,
+      data: {
+        texture: 'arrow',
+        frame: 0,
+      }
+    },
+    {
+      component: PhysicsBodyComponent,
+    },
+    {
+      component: AttachmentComponent,
+      data: {
+        attachmentDebug: false,
+      }
+    },
+    {
+      component: HitboxComponent,
+      data: {
+        hitboxesKey: 'arrow-hitboxes',
+      }
+    },
+    {
+      component: PhiniteStateMachineComponent,
+      data: {
+        stateSet: 'arrow',
+        initialStateId: 'arrow-disabled',
+      }
+    },
+    {
+      component: BoundsComponent,
+      data: {
+        boundsKey: 'arrow-bounds',
+      }
+    }
+  ]
 };

--- a/src/entities/arrow/prefab.ts
+++ b/src/entities/arrow/prefab.ts
@@ -4,6 +4,7 @@ import { AttachmentComponent } from "../../components/attachment-component";
 import { HitboxComponent } from "../../components/hitbox-component";
 import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
 import { BoundsComponent } from "../../components/bounds-component";
+import { ArrowComponent } from "../../components/arrow-component";
 
 export const arrowPrefab: Phecs.Prefab = {
   components: [
@@ -41,6 +42,9 @@ export const arrowPrefab: Phecs.Prefab = {
       data: {
         boundsKey: 'arrow-bounds',
       }
+    },
+    {
+      component: ArrowComponent
     }
   ]
 };

--- a/src/entities/arrow/states/disabled.ts
+++ b/src/entities/arrow/states/disabled.ts
@@ -6,17 +6,17 @@ export const disabled: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'arrow-disabled',
   transitions: [],
   onEnter(arrow) {
-    arrow.components[SpriteComponent.tag].sprite.active = false;
-    arrow.components[SpriteComponent.tag].sprite.visible = false;
-    arrow.components[PhysicsBodyComponent.tag].body.enable = false;
-    arrow.components[PhysicsBodyComponent.tag].body.allowGravity = false;
-    arrow.components[HitboxComponent.tag].disable();
+    arrow.getComponent(SpriteComponent).sprite.active = false;
+    arrow.getComponent(SpriteComponent).sprite.visible = false;
+    arrow.getComponent(PhysicsBodyComponent).body.enable = false;
+    arrow.getComponent(PhysicsBodyComponent).body.allowGravity = false;
+    arrow.getComponent(HitboxComponent).disable();
   },
   onLeave(arrow) {
-    arrow.components[SpriteComponent.tag].sprite.active = true;
-    arrow.components[SpriteComponent.tag].sprite.visible = true;
-    arrow.components[PhysicsBodyComponent.tag].body.enable = true;
-    arrow.components[PhysicsBodyComponent.tag].body.allowGravity = true;
-    arrow.components[HitboxComponent.tag].enable();
+    arrow.getComponent(SpriteComponent).sprite.active = true;
+    arrow.getComponent(SpriteComponent).sprite.visible = true;
+    arrow.getComponent(PhysicsBodyComponent).body.enable = true;
+    arrow.getComponent(PhysicsBodyComponent).body.allowGravity = true;
+    arrow.getComponent(HitboxComponent).enable();
   }
 }

--- a/src/entities/arrow/states/flying.ts
+++ b/src/entities/arrow/states/flying.ts
@@ -8,23 +8,23 @@ export const flying: PhiniteStateMachine.States.State<Phecs.Entity> = {
     {
       type: TransitionType.Conditional,
       condition(arrow) {
-        return !arrow.components[PhysicsBodyComponent.tag].body.blocked.none;
+        return !arrow.getComponent(PhysicsBodyComponent).body.blocked.none;
       },
       to: 'arrow-hit',
     }
   ],
   onEnter(arrow) {
-    arrow.components[SpriteComponent.tag].sprite.active = true;
-    arrow.components[SpriteComponent.tag].sprite.visible = true;
-    arrow.components[PhysicsBodyComponent.tag].body.enable = true;
-    arrow.components[PhysicsBodyComponent.tag].body.allowGravity = true;
+    arrow.getComponent(SpriteComponent).sprite.active = true;
+    arrow.getComponent(SpriteComponent).sprite.visible = true;
+    arrow.getComponent(PhysicsBodyComponent).body.enable = true;
+    arrow.getComponent(PhysicsBodyComponent).body.allowGravity = true;
 
-    arrow.components[PhysicsBodyComponent.tag].body.setVelocity(400, 0);
+    arrow.getComponent(PhysicsBodyComponent).body.setVelocity(400, 0);
   },
   onUpdate(arrow) {
-    if (arrow.components[PhysicsBodyComponent.tag].body.blocked.none) {
-      const angle = Math.atan2(arrow.components[PhysicsBodyComponent.tag].body.velocity.y, arrow.components[PhysicsBodyComponent.tag].body.velocity.x);
-      arrow.components[SpriteComponent.tag].sprite.rotation = angle;
+    if (arrow.getComponent(PhysicsBodyComponent).body.blocked.none) {
+      const angle = Math.atan2(arrow.getComponent(PhysicsBodyComponent).body.velocity.y, arrow.getComponent(PhysicsBodyComponent).body.velocity.x);
+      arrow.getComponent(SpriteComponent).sprite.rotation = angle;
     }
   }
 }

--- a/src/entities/arrow/states/hit.ts
+++ b/src/entities/arrow/states/hit.ts
@@ -4,7 +4,7 @@ export const hit: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'arrow-hit',
   transitions: [],
   onEnter(arrow) {
-    arrow.components[PhysicsBodyComponent.tag].body.setVelocity(0, 0);
-    arrow.components[PhysicsBodyComponent.tag].body.allowGravity = false;
+    arrow.getComponent(PhysicsBodyComponent).body.setVelocity(0, 0);
+    arrow.getComponent(PhysicsBodyComponent).body.allowGravity = false;
   }
 }

--- a/src/entities/door/prefab.ts
+++ b/src/entities/door/prefab.ts
@@ -1,10 +1,30 @@
-export const doorPrefab = {
-  tags: 'sprite,door,indicator,interaction-circle',
+import { SpriteComponent } from "../../components/sprite-component";
+import { DoorComponent } from "../../components/door-component";
+import { IndicatorComponent } from "../../components/indicator-component";
+import { InteractionCircleComponent } from "../../components/interaction-circle-component";
 
-  texture: 'doors',
-  frame: 1,
-  depth: 2,
-
-  interactionControl: 'action',
-  interactionRadius: 40,
+export const doorPrefab: Phecs.Prefab = {
+  components: [
+    {
+      component: SpriteComponent,
+      data: {
+        texture: 'doors',
+        frame: 1,
+        depth: 2,
+      }
+    },
+    {
+      component: DoorComponent,
+    },
+    {
+      component: IndicatorComponent,
+    },
+    {
+      component: InteractionCircleComponent,
+      data: {
+        interactionControl: 'action',
+        interactionRadius: 40,
+      }
+    }
+  ]
 }

--- a/src/entities/enemy/prefab.ts
+++ b/src/entities/enemy/prefab.ts
@@ -8,6 +8,7 @@ import { HealthComponent } from "../../components/health-component";
 import { InteractionCircleComponent } from "../../components/interaction-circle-component";
 import { EnemyComponent } from "../../components/enemy-component";
 import { ZoneBoundaryComponent } from "../../components/zone-boundary-component";
+import { SceneComponent } from "../../components/scene-component";
 
 export const enemyPrefab: Phecs.Prefab = {
   components: [
@@ -67,6 +68,9 @@ export const enemyPrefab: Phecs.Prefab = {
       data: {
         zoneBoundaryName: 'enemyBounds',
       }
+    },
+    {
+      component: SceneComponent,
     }
   ]
 };

--- a/src/entities/enemy/prefab.ts
+++ b/src/entities/enemy/prefab.ts
@@ -1,23 +1,72 @@
-export const enemyPrefab = {
-  name: 'enemy',
+import { SpriteComponent } from "../../components/sprite-component";
+import { PhysicsBodyComponent } from "../../components/physics-body-component";
+import { AttachmentComponent } from "../../components/attachment-component";
+import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
+import { HurtboxComponent } from "../../components/hurtbox-component";
+import { HitboxComponent } from "../../components/hitbox-component";
+import { HealthComponent } from "../../components/health-component";
+import { InteractionCircleComponent } from "../../components/interaction-circle-component";
+import { EnemyComponent } from "../../components/enemy-component";
+import { ZoneBoundaryComponent } from "../../components/zone-boundary-component";
 
-  tags: 'sprite,physics-body,attachment,phinite-state-machine,hurtbox,hitbox,health,interaction-circle,enemy,zone-boundary',
-
-  attachmentDebug: false,
-
-  texture: 'enemy',
-  frame: 0,
-
-  stateSet: 'enemy',
-  initialStateId: 'enemy-idle',
-
-  hurtboxesKey: 'enemy-hurtboxes',
-  hitboxesKey: 'enemy-hitboxes',
-
-  maxHealth: 2,
-
-  interactionRadius: 220,
-  interactionDebug: false,
-
-  zoneBoundaryName: 'enemyBounds',
+export const enemyPrefab: Phecs.Prefab = {
+  components: [
+    {
+      component: SpriteComponent,
+      data: {
+        texture: 'enemy',
+        frame: 0,
+      }
+    },
+    {
+      component: PhysicsBodyComponent,
+    },
+    {
+      component: AttachmentComponent,
+      data: {
+        attachmentDebug: false,
+      }
+    },
+    {
+      component: PhiniteStateMachineComponent,
+      data: {
+        stateSet: 'enemy',
+        initialStateId: 'enemy-idle',
+      }
+    },
+    {
+      component: HurtboxComponent,
+      data: {
+        hurtboxesKey: 'enemy-hurtboxes',
+      }
+    },
+    {
+      component: HitboxComponent,
+      data: {
+        hitboxesKey: 'enemy-hitboxes',
+      }
+    },
+    {
+      component: HealthComponent,
+      data: {
+        maxHealth: 2,
+      }
+    },
+    {
+      component: InteractionCircleComponent,
+      data: {
+        interactionRadius: 220,
+        interactionDebug: false,
+      }
+    },
+    {
+      component: EnemyComponent,
+    },
+    {
+      component: ZoneBoundaryComponent,
+      data: {
+        zoneBoundaryName: 'enemyBounds',
+      }
+    }
+  ]
 };

--- a/src/entities/enemy/states/dead.ts
+++ b/src/entities/enemy/states/dead.ts
@@ -1,6 +1,7 @@
 import { SpriteComponent } from '../../../components/sprite-component';
 import { PhysicsBodyComponent } from '../../../components/physics-body-component';
 import { HurtboxComponent } from '../../../components/hurtbox-component';
+import { SceneComponent } from '../../../components/scene-component';
 
 export const dead: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-dead',
@@ -11,7 +12,7 @@ export const dead: PhiniteStateMachine.States.State<Phecs.Entity> = {
     enemy.getComponent(PhysicsBodyComponent).body.enable = false;
     enemy.getComponent(HurtboxComponent).disable();
 
-    sprite.scene.tweens.add({
+    enemy.getComponent(SceneComponent).scene.tweens.add({
       targets: [sprite],
       props: {
         alpha: 0,

--- a/src/entities/enemy/states/dead.ts
+++ b/src/entities/enemy/states/dead.ts
@@ -5,11 +5,11 @@ import { HurtboxComponent } from '../../../components/hurtbox-component';
 export const dead: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-dead',
   onEnter(enemy) {
-    const sprite = enemy.components[SpriteComponent.tag].sprite;
+    const sprite = enemy.getComponent(SpriteComponent).sprite;
     sprite.anims.stop();
 
-    enemy.components[PhysicsBodyComponent.tag].body.enable = false;
-    enemy.components[HurtboxComponent.tag].disable();
+    enemy.getComponent(PhysicsBodyComponent).body.enable = false;
+    enemy.getComponent(HurtboxComponent).disable();
 
     sprite.scene.tweens.add({
       targets: [sprite],

--- a/src/entities/enemy/states/fall.ts
+++ b/src/entities/enemy/states/fall.ts
@@ -5,13 +5,13 @@ import { PhysicsBodyComponent } from '../../../components/physics-body-component
 export const fall: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-fall',
   onEnter(enemy) {
-    enemy.components[SpriteComponent.tag].sprite.anims.play('enemy-jump');
+    enemy.getComponent(SpriteComponent).sprite.anims.play('enemy-jump');
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const body = enemy.components[PhysicsBodyComponent.tag].body;
+        const body = enemy.getComponent(PhysicsBodyComponent).body;
 
         return body.blocked.down;
       },

--- a/src/entities/enemy/states/idle.ts
+++ b/src/entities/enemy/states/idle.ts
@@ -30,7 +30,7 @@ export const idle: PhiniteStateMachine.States.State<Phecs.Entity> = {
         const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
         for (let entityId of activeEntityIds) {
           const entity = scene.phecs.phEntities.getEntityById(entityId);
-          if (entity && entity.getComponent(AdventurerComponent)) {
+          if (entity.hasComponent(AdventurerComponent)) {
             return true;
           }
         }

--- a/src/entities/enemy/states/idle.ts
+++ b/src/entities/enemy/states/idle.ts
@@ -4,6 +4,7 @@ import { InteractionCircleComponent } from '../../../components/interaction-circ
 import { BaseScene } from '../../../scenes/base-scene';
 import { AdventurerComponent } from '../../../components/adventurer-component';
 import { PhysicsBodyComponent } from '../../../components/physics-body-component';
+import { SceneComponent } from '../../../components/scene-component';
 
 export const idle: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-idle',
@@ -26,8 +27,7 @@ export const idle: PhiniteStateMachine.States.State<Phecs.Entity> = {
       condition(enemy) {
         const activeEntityIds = enemy.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
 
-        // This is gross and there has to be a better way to get at Phecs
-        const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
+        const scene = enemy.getComponent(SceneComponent).scene as BaseScene;
         for (let entityId of activeEntityIds) {
           const entity = scene.phecs.phEntities.getEntityById(entityId);
           if (entity.hasComponent(AdventurerComponent)) {

--- a/src/entities/enemy/states/idle.ts
+++ b/src/entities/enemy/states/idle.ts
@@ -8,10 +8,10 @@ import { PhysicsBodyComponent } from '../../../components/physics-body-component
 export const idle: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-idle',
   onEnter(enemy) {
-    const body = enemy.components[PhysicsBodyComponent.tag].body;
+    const body = enemy.getComponent(PhysicsBodyComponent).body;
     body.velocity.x = 0;
 
-    enemy.components[SpriteComponent.tag].sprite.anims.play('enemy-idle');
+    enemy.getComponent(SpriteComponent).sprite.anims.play('enemy-idle');
   },
   transitions: [
     {
@@ -24,13 +24,13 @@ export const idle: PhiniteStateMachine.States.State<Phecs.Entity> = {
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const activeEntityIds = enemy.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('active');
+        const activeEntityIds = enemy.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
 
         // This is gross and there has to be a better way to get at Phecs
-        const scene = enemy.components[SpriteComponent.tag].sprite.scene as BaseScene;
+        const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
         for (let entityId of activeEntityIds) {
           const entity = scene.phecs.phEntities.getEntityById(entityId);
-          if (entity && entity.components[AdventurerComponent.tag]) {
+          if (entity && entity.getComponent(AdventurerComponent)) {
             return true;
           }
         }

--- a/src/entities/enemy/states/jump.ts
+++ b/src/entities/enemy/states/jump.ts
@@ -7,15 +7,15 @@ import { movementAttributes } from '../movement-attributes';
 export const jump: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-jump',
   onEnter(enemy) {
-    enemy.components[SpriteComponent.tag].sprite.anims.play('enemy-jump');
+    enemy.getComponent(SpriteComponent).sprite.anims.play('enemy-jump');
 
-    enemy.components[PhysicsBodyComponent.tag].body.velocity.y = movementAttributes.jumpVelocity;
+    enemy.getComponent(PhysicsBodyComponent).body.velocity.y = movementAttributes.jumpVelocity;
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const body = enemy.components[PhysicsBodyComponent.tag].body;
+        const body = enemy.getComponent(PhysicsBodyComponent).body;
 
         return body.velocity.y <= 0;
       },

--- a/src/entities/enemy/states/stun.ts
+++ b/src/entities/enemy/states/stun.ts
@@ -1,6 +1,7 @@
 import { SpriteComponent } from '../../../components/sprite-component';
 import { TransitionType } from '../../../lib/phinite-state-machine/transition-type';
 import { PhysicsBodyComponent } from '../../../components/physics-body-component';
+import { SceneComponent } from '../../../components/scene-component';
 
 export const stun: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-stun',
@@ -13,7 +14,7 @@ export const stun: PhiniteStateMachine.States.State<Phecs.Entity> = {
     body.velocity.x = 0;
     body.velocity.y = 0;
 
-    sprite.scene.tweens.timeline({
+    enemy.getComponent(SceneComponent).scene.tweens.timeline({
       tweens: [
         {
           targets: sprite,
@@ -44,7 +45,7 @@ export const stun: PhiniteStateMachine.States.State<Phecs.Entity> = {
       condition(enemy) {
         const sprite = enemy.getComponent(SpriteComponent).sprite;
 
-        return !sprite.scene.tweens.isTweening(sprite);
+        return !enemy.getComponent(SceneComponent).scene.tweens.isTweening(sprite);
       },
       to(enemy) {
         const body = enemy.getComponent(PhysicsBodyComponent).body;

--- a/src/entities/enemy/states/stun.ts
+++ b/src/entities/enemy/states/stun.ts
@@ -5,8 +5,8 @@ import { PhysicsBodyComponent } from '../../../components/physics-body-component
 export const stun: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-stun',
   onEnter(enemy) {
-    const sprite = enemy.components[SpriteComponent.tag].sprite;
-    const body = enemy.components[PhysicsBodyComponent.tag].body;
+    const sprite = enemy.getComponent(SpriteComponent).sprite;
+    const body = enemy.getComponent(PhysicsBodyComponent).body;
 
     sprite.anims.stop();
     body.allowGravity = false;
@@ -34,7 +34,7 @@ export const stun: PhiniteStateMachine.States.State<Phecs.Entity> = {
     });
   },
   onLeave(enemy) {
-    const body = enemy.components[PhysicsBodyComponent.tag].body;
+    const body = enemy.getComponent(PhysicsBodyComponent).body;
 
     body.allowGravity = true;
   },
@@ -42,12 +42,12 @@ export const stun: PhiniteStateMachine.States.State<Phecs.Entity> = {
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const sprite = enemy.components[SpriteComponent.tag].sprite;
+        const sprite = enemy.getComponent(SpriteComponent).sprite;
 
         return !sprite.scene.tweens.isTweening(sprite);
       },
       to(enemy) {
-        const body = enemy.components[PhysicsBodyComponent.tag].body;
+        const body = enemy.getComponent(PhysicsBodyComponent).body;
 
         if (body.blocked.down) {
           return 'enemy-idle';

--- a/src/entities/enemy/states/track-adventurer.ts
+++ b/src/entities/enemy/states/track-adventurer.ts
@@ -5,6 +5,7 @@ import { BaseScene } from '../../../scenes/base-scene';
 import { PhysicsBodyComponent } from '../../../components/physics-body-component';
 import { movementAttributes } from '../movement-attributes';
 import { AdventurerComponent } from '../../../components/adventurer-component';
+import { SceneComponent } from '../../../components/scene-component';
 
 export const trackAdventurer: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-track-adventurer',
@@ -12,7 +13,7 @@ export const trackAdventurer: PhiniteStateMachine.States.State<Phecs.Entity> = {
     enemy.getComponent(SpriteComponent).sprite.anims.play('enemy-jump');
   },
   onUpdate(enemy) {
-    const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
+    const scene = enemy.getComponent(SceneComponent).scene as BaseScene;
 
     const adventurer = scene.phecs.phEntities.getEntitiesByComponent(AdventurerComponent)[0];
     const adventurerSprite = adventurer.getComponent(SpriteComponent).sprite;
@@ -37,7 +38,7 @@ export const trackAdventurer: PhiniteStateMachine.States.State<Phecs.Entity> = {
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
+        const scene = enemy.getComponent(SceneComponent).scene as BaseScene;
         const activeEntityIds = enemy.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
 
         const adventurerId = scene.phecs.phEntities.getEntitiesByComponent(AdventurerComponent)[0].id;

--- a/src/entities/enemy/states/track-adventurer.ts
+++ b/src/entities/enemy/states/track-adventurer.ts
@@ -4,20 +4,21 @@ import { InteractionCircleComponent } from '../../../components/interaction-circ
 import { BaseScene } from '../../../scenes/base-scene';
 import { PhysicsBodyComponent } from '../../../components/physics-body-component';
 import { movementAttributes } from '../movement-attributes';
+import { AdventurerComponent } from '../../../components/adventurer-component';
 
 export const trackAdventurer: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-track-adventurer',
   onEnter(enemy) {
-    enemy.components[SpriteComponent.tag].sprite.anims.play('enemy-jump');
+    enemy.getComponent(SpriteComponent).sprite.anims.play('enemy-jump');
   },
   onUpdate(enemy) {
-    const scene = enemy.components[SpriteComponent.tag].sprite.scene as BaseScene;
+    const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
 
-    const adventurer = scene.phecs.phEntities.getEntitiesByName('adventurer')[0];
-    const adventurerSprite = adventurer.components[SpriteComponent.tag].sprite;
+    const adventurer = scene.phecs.phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const adventurerSprite = adventurer.getComponent(SpriteComponent).sprite;
 
-    const enemySprite = enemy.components[SpriteComponent.tag].sprite;
-    const enemyBody = enemy.components[PhysicsBodyComponent.tag].body;
+    const enemySprite = enemy.getComponent(SpriteComponent).sprite;
+    const enemyBody = enemy.getComponent(PhysicsBodyComponent).body;
 
     if (enemySprite.x < adventurerSprite.x) {
       enemyBody.velocity.x = movementAttributes.trackingVelocity;
@@ -36,10 +37,10 @@ export const trackAdventurer: PhiniteStateMachine.States.State<Phecs.Entity> = {
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const scene = enemy.components[SpriteComponent.tag].sprite.scene as BaseScene;
-        const activeEntityIds = enemy.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('active');
+        const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
+        const activeEntityIds = enemy.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
 
-        const adventurerId = scene.phecs.phEntities.getEntitiesByName('adventurer')[0].id;
+        const adventurerId = scene.phecs.phEntities.getEntitiesByComponent(AdventurerComponent)[0].id;
 
         return !activeEntityIds.includes(adventurerId);
       },

--- a/src/entities/enemy/states/wander.ts
+++ b/src/entities/enemy/states/wander.ts
@@ -10,8 +10,8 @@ import { ZoneBoundaryComponent } from '../../../components/zone-boundary-compone
 export const wander: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-wander',
   onEnter(enemy) {
-    const sprite = enemy.components[SpriteComponent.tag].sprite;
-    const body = enemy.components[PhysicsBodyComponent.tag].body;
+    const sprite = enemy.getComponent(SpriteComponent).sprite;
+    const body = enemy.getComponent(PhysicsBodyComponent).body;
     body.velocity.x = Phaser.Math.RND.pick([-1, 1]) * movementAttributes.wanderVelocity;
 
     if (body.velocity.x < 0) {
@@ -21,9 +21,9 @@ export const wander: PhiniteStateMachine.States.State<Phecs.Entity> = {
     }
   },
   onUpdate(enemy) {
-    const sprite = enemy.components[SpriteComponent.tag].sprite as Phaser.GameObjects.Sprite;
-    const body = enemy.components[PhysicsBodyComponent.tag].body;
-    const zone = enemy.components[ZoneBoundaryComponent.tag].zone;
+    const sprite = enemy.getComponent(SpriteComponent).sprite as Phaser.GameObjects.Sprite;
+    const body = enemy.getComponent(PhysicsBodyComponent).body;
+    const zone = enemy.getComponent(ZoneBoundaryComponent).zone;
 
     if (!Phaser.Geom.Rectangle.ContainsRect(zone, sprite.getBounds())) {
       body.velocity.x *= -1;
@@ -40,13 +40,13 @@ export const wander: PhiniteStateMachine.States.State<Phecs.Entity> = {
     {
       type: TransitionType.Conditional,
       condition(enemy) {
-        const activeEntityIds = enemy.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('active');
+        const activeEntityIds = enemy.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
 
         // This is gross and there has to be a better way to get at Phecs
-        const scene = enemy.components[SpriteComponent.tag].sprite.scene as BaseScene;
+        const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
         for (let entityId of activeEntityIds) {
           const entity = scene.phecs.phEntities.getEntityById(entityId);
-          if (entity && entity.components[AdventurerComponent.tag]) {
+          if (entity && entity.getComponent(AdventurerComponent)) {
             return true;
           }
         }

--- a/src/entities/enemy/states/wander.ts
+++ b/src/entities/enemy/states/wander.ts
@@ -46,7 +46,7 @@ export const wander: PhiniteStateMachine.States.State<Phecs.Entity> = {
         const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
         for (let entityId of activeEntityIds) {
           const entity = scene.phecs.phEntities.getEntityById(entityId);
-          if (entity && entity.getComponent(AdventurerComponent)) {
+          if (entity.hasComponent(AdventurerComponent)) {
             return true;
           }
         }

--- a/src/entities/enemy/states/wander.ts
+++ b/src/entities/enemy/states/wander.ts
@@ -6,6 +6,7 @@ import { SpriteComponent } from '../../../components/sprite-component';
 import { BaseScene } from '../../../scenes/base-scene';
 import { AdventurerComponent } from '../../../components/adventurer-component';
 import { ZoneBoundaryComponent } from '../../../components/zone-boundary-component';
+import { SceneComponent } from '../../../components/scene-component';
 
 export const wander: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'enemy-wander',
@@ -42,8 +43,7 @@ export const wander: PhiniteStateMachine.States.State<Phecs.Entity> = {
       condition(enemy) {
         const activeEntityIds = enemy.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
 
-        // This is gross and there has to be a better way to get at Phecs
-        const scene = enemy.getComponent(SpriteComponent).sprite.scene as BaseScene;
+        const scene = enemy.getComponent(SceneComponent).scene as BaseScene;
         for (let entityId of activeEntityIds) {
           const entity = scene.phecs.phEntities.getEntityById(entityId);
           if (entity.hasComponent(AdventurerComponent)) {

--- a/src/entities/sheep/prefab.ts
+++ b/src/entities/sheep/prefab.ts
@@ -1,14 +1,33 @@
-export const sheepPrefab = {
-  name: 'sheep',
+import { SpriteComponent } from "../../components/sprite-component";
+import { PhysicsBodyComponent } from "../../components/physics-body-component";
+import { PhiniteStateMachineComponent } from "../../components/phinite-state-machine-component";
+import { ZoneBoundaryComponent } from "../../components/zone-boundary-component";
 
-  tags: 'sprite,physics-body,phinite-state-machine,zone-boundary',
-
-  zoneBoundaryName: 'sheepBounds',
-
-  texture: 'sheep-walk',
-  frame: 0,
-  depth: 0,
-
-  stateSet: 'sheep',
-  initialStateId: 'sheep-walk-right',
+export const sheepPrefab: Phecs.Prefab = {
+  components: [
+    {
+      component: SpriteComponent,
+      data: {
+        texture: 'sheep-walk',
+        frame: 0,
+        depth: 0,
+      }
+    },
+    {
+      component: PhysicsBodyComponent
+    },
+    {
+      component: PhiniteStateMachineComponent,
+      data: {
+        stateSet: 'sheep',
+        initialStateId: 'sheep-walk-right',
+      }
+    },
+    {
+      component: ZoneBoundaryComponent,
+      data: {
+        zoneBoundaryName: 'sheepBounds',
+      }
+    }
+  ]
 };

--- a/src/entities/sheep/states/walk-left.ts
+++ b/src/entities/sheep/states/walk-left.ts
@@ -6,17 +6,17 @@ import { ZoneBoundaryComponent } from '../../../components/zone-boundary-compone
 export const walkLeft: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'sheep-walk-left',
   onEnter(sheep: Phecs.Entity) {
-    sheep.components[SpriteComponent.tag].sprite.anims.play('sheep-walk');
-    sheep.components[SpriteComponent.tag].sprite.flipX = true;
+    sheep.getComponent(SpriteComponent).sprite.anims.play('sheep-walk');
+    sheep.getComponent(SpriteComponent).sprite.flipX = true;
 
-    sheep.components[PhysicsBodyComponent.tag].body.velocity.x = -50;
+    sheep.getComponent(PhysicsBodyComponent).body.velocity.x = -50;
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(sheep: Phecs.Entity) {
-        const sprite = sheep.components[SpriteComponent.tag].sprite;
-        const zone = sheep.components[ZoneBoundaryComponent.tag].zone;
+        const sprite = sheep.getComponent(SpriteComponent).sprite;
+        const zone = sheep.getComponent(ZoneBoundaryComponent).zone;
 
         return (sprite.x) < (zone.x);
       },

--- a/src/entities/sheep/states/walk-right.ts
+++ b/src/entities/sheep/states/walk-right.ts
@@ -6,17 +6,17 @@ import { ZoneBoundaryComponent } from '../../../components/zone-boundary-compone
 export const walkRight: PhiniteStateMachine.States.State<Phecs.Entity> = {
   id: 'sheep-walk-right',
   onEnter(sheep: Phecs.Entity) {
-    sheep.components[SpriteComponent.tag].sprite.anims.play('sheep-walk');
-    sheep.components[SpriteComponent.tag].sprite.flipX = false;
+    sheep.getComponent(SpriteComponent).sprite.anims.play('sheep-walk');
+    sheep.getComponent(SpriteComponent).sprite.flipX = false;
 
-    sheep.components[PhysicsBodyComponent.tag].body.velocity.x = 50;
+    sheep.getComponent(PhysicsBodyComponent).body.velocity.x = 50;
   },
   transitions: [
     {
       type: TransitionType.Conditional,
       condition(sheep: Phecs.Entity) {
-        const sprite = sheep.components[SpriteComponent.tag].sprite;
-        const zone = sheep.components[ZoneBoundaryComponent.tag].zone;
+        const sprite = sheep.getComponent(SpriteComponent).sprite;
+        const zone = sheep.getComponent(ZoneBoundaryComponent).zone;
 
         return (sprite.x + sprite.width) > (zone.x + zone.width);
       },

--- a/src/entities/sign/prefab.ts
+++ b/src/entities/sign/prefab.ts
@@ -2,7 +2,6 @@ import { SpriteComponent } from "../../components/sprite-component";
 import { InteractionCircleComponent } from "../../components/interaction-circle-component";
 import { IndicatorComponent } from "../../components/indicator-component";
 import { TextboxComponent } from "../../components/textbox-component";
-import { SignComponent } from "../../components/sign-component";
 
 export const signPrefab: Phecs.Prefab = {
   components: [
@@ -23,9 +22,6 @@ export const signPrefab: Phecs.Prefab = {
     },
     {
       component: IndicatorComponent
-    },
-    {
-      component: SignComponent
     },
     {
       component: TextboxComponent

--- a/src/entities/sign/prefab.ts
+++ b/src/entities/sign/prefab.ts
@@ -1,10 +1,34 @@
-export const signPrefab = {
-  tags: 'sprite,interaction-circle,indicator,sign,textbox',
+import { SpriteComponent } from "../../components/sprite-component";
+import { InteractionCircleComponent } from "../../components/interaction-circle-component";
+import { IndicatorComponent } from "../../components/indicator-component";
+import { TextboxComponent } from "../../components/textbox-component";
+import { SignComponent } from "../../components/sign-component";
 
-  texture: 'core-tileset-spritesheet',
-  frame: 1128,
-
-  interactionRadius: 30,
-  interactionControl: 'action',
-  interactionDebug: false,
+export const signPrefab: Phecs.Prefab = {
+  components: [
+    {
+      component: SpriteComponent,
+      data: {
+        texture: 'core-tileset-spritesheet',
+        frame: 1128,
+      }
+    },
+    {
+      component: InteractionCircleComponent,
+      data: {
+        interactionRadius: 30,
+        interactionControl: 'action',
+        interactionDebug: false,
+      }
+    },
+    {
+      component: IndicatorComponent
+    },
+    {
+      component: SignComponent
+    },
+    {
+      component: TextboxComponent
+    }
+  ]
 }

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -9,7 +9,6 @@ export class BaseEntity implements Phecs.Entity {
     this.components = [];
   }
 
-  // TODO: make this a util method
   getComponent<T extends Phecs.ComponentConstructor>(componentKlass: T): InstanceType<T> {
     const foundComponent = this.components.find(component => {
       return this.isComponent(component, componentKlass);

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -10,22 +10,26 @@ export class BaseEntity implements Phecs.Entity {
   }
 
   // TODO: make this a util method
-  getComponent<T extends Phecs.ComponentConstructor>(component: T): InstanceType<T> {
-    const foundComponent = this.components.find(entityComponent => {
-      return component.name === entityComponent.__proto__.constructor.name;
+  getComponent<T extends Phecs.ComponentConstructor>(componentKlass: T): InstanceType<T> {
+    const foundComponent = this.components.find(component => {
+      return this.isComponent(component, componentKlass);
     });
 
     if (foundComponent) {
       return foundComponent as InstanceType<T>;
     }
 
-    throw new Error(`BaseEntity::NO_COMPONENT_${typeof component}`);
+    throw new Error(`BaseEntity::NO_COMPONENT_${typeof componentKlass}`);
   }
 
-  hasComponent<T extends Phecs.ComponentConstructor>(component: T): boolean {
-    return this.components.some(entityComponent => {
-      return component.name === entityComponent.__proto__.constructor.name;
+  hasComponent<T extends Phecs.ComponentConstructor>(componentKlass: T): boolean {
+    return this.components.some(component => {
+      return this.isComponent(component, componentKlass);
     });
+  }
+
+  private isComponent(component: Phecs.Component, componentKlass: Phecs.ComponentConstructor) {
+    return componentKlass.name === component.__proto__.constructor.name;
   }
 
   private generateUuid() {

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -22,6 +22,12 @@ export class BaseEntity implements Phecs.Entity {
     throw new Error(`BaseEntity::NO_COMPONENT_${typeof component}`);
   }
 
+  hasComponent<T extends Phecs.ComponentConstructor>(component: T): boolean {
+    return this.components.some(entityComponent => {
+      return component.name === entityComponent.__proto__.constructor.name;
+    });
+  }
+
   private generateUuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
       const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -1,0 +1,20 @@
+export class BaseEntity implements Phecs.Entity {
+  public id: string;
+  public components: Phecs.Component[];
+
+  constructor() {
+    this.id = this.generateUuid();
+    this.components = [];
+  }
+
+  getComponent<T extends Phecs.Component>(component: T): T {
+    return this.components.find(entityComponent => typeof entityComponent === typeof component) as T;
+  }
+
+  private generateUuid() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  }
+}

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -1,12 +1,15 @@
 export class BaseEntity implements Phecs.Entity {
+  public type: string;
   public id: string;
   public components: Phecs.Component[];
 
-  constructor() {
+  constructor(type: string) {
+    this.type = type;
     this.id = this.generateUuid();
     this.components = [];
   }
 
+  // TODO: make this a util method
   getComponent<T extends Phecs.ComponentConstructor>(component: T): InstanceType<T> {
     const foundComponent = this.components.find(entityComponent => {
       return component.name === entityComponent.__proto__.constructor.name;

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -7,8 +7,14 @@ export class BaseEntity implements Phecs.Entity {
     this.components = [];
   }
 
-  getComponent<T extends Phecs.Component>(component: T): T {
-    return this.components.find(entityComponent => typeof entityComponent === typeof component) as T;
+  getComponent<T extends Phecs.ComponentConstructor>(component: T): InstanceType<T> {
+    const foundComponent = this.components.find(entityComponent => typeof entityComponent === typeof component);
+
+    if (foundComponent) {
+      return foundComponent as InstanceType<T>;
+    }
+
+    throw new Error(`BaseEntity::NO_COMPONENT_${typeof component}`);
   }
 
   private generateUuid() {

--- a/src/lib/phecs/base-entity.ts
+++ b/src/lib/phecs/base-entity.ts
@@ -8,7 +8,9 @@ export class BaseEntity implements Phecs.Entity {
   }
 
   getComponent<T extends Phecs.ComponentConstructor>(component: T): InstanceType<T> {
-    const foundComponent = this.components.find(entityComponent => typeof entityComponent === typeof component);
+    const foundComponent = this.components.find(entityComponent => {
+      return component.name === entityComponent.__proto__.constructor.name;
+    });
 
     if (foundComponent) {
       return foundComponent as InstanceType<T>;

--- a/src/lib/phecs/entity-manager.ts
+++ b/src/lib/phecs/entity-manager.ts
@@ -1,24 +1,22 @@
 import { BaseScene } from '../../scenes/base-scene';
 import { TiledUtil } from '../../utilities/tiled-util';
+import { BaseEntity } from './base-entity';
 
 type PrefabMap = { [key: string]: Phecs.Prefab };
-type EntitiesMap = { [name: string]: Phecs.Entity[] };
 type EntityMap = { [name: string]: Phecs.Entity };
 
 export class EntityManager {
   private scene: BaseScene;
 
   private prefabs: PrefabMap;
-  private entitiesByName: EntitiesMap;
-  private entitiesByTag: EntitiesMap;
   private entitiesById: EntityMap;
+  private entities: Phecs.Entity[];
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene as BaseScene;
     this.prefabs = {};
-    this.entitiesByName = {};
-    this.entitiesByTag = {};
     this.entitiesById = {};
+    this.entities = [];
   }
 
   registerPrefab(key: string, prefab: Phecs.Prefab) {
@@ -29,48 +27,34 @@ export class EntityManager {
     const prefab = this.prefabs[key];
     const entity = this.createEntity(prefab, tiledProperties, depth, x, y);
 
-    this.entitiesByName[key] = this.entitiesByName[key] || [];
-    this.entitiesByName[key].push(entity);
-
     return entity;
-  }
-
-  getEntitiesByName(name: string) {
-    return this.entitiesByName[name] || [];
-  }
-
-  getEntitiesByTag(tag: string) {
-    return this.entitiesByTag[tag] || [];
   }
 
   getEntityById(id: string) {
     return this.entitiesById[id];
   }
 
+  getEntitiesByComponent(component: Phecs.Component) {
+    return this.entities.filter(entity => {
+      return entity.components.some(entityComponent => {
+        return typeof entityComponent === typeof component;
+      })
+    });
+  }
+
   destroy() {
-    const entities: Phecs.Entity[] = [];
-    Object.values(this.entitiesByTag).flat().forEach(entity => {
-      if (!entities.includes(entity)) {
-        entities.push(entity);
-      }
+    this.entities.forEach(entity => {
+      entity.components.forEach(component => component.destroy());
     });
 
-    entities.forEach(entity => {
-      Object.values(entity.components).forEach(component => component.destroy());
-    });
-
-    this.entitiesByName = {};
-    this.entitiesByTag = {};
     this.entitiesById = {};
+    this.entities = [];
   }
 
   private createEntity(prefab: Phecs.Prefab, tiledProperties: any, depth: number = 0, x: number = 0, y: number = 0) {
     const baseScene = this.scene as BaseScene;
 
-    const entity = {
-      id: this.generateUuid(),
-      components: [],
-    } as any;
+   const entity = new BaseEntity();
 
     const properties = {
       ...TiledUtil.normalizeProperties(tiledProperties)
@@ -93,10 +77,4 @@ export class EntityManager {
     return entity;
   }
 
-  private generateUuid() {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-      return v.toString(16);
-    });
-  }
 }

--- a/src/lib/phecs/entity-manager.ts
+++ b/src/lib/phecs/entity-manager.ts
@@ -15,6 +15,7 @@ export class EntityManager {
   constructor(scene: Phaser.Scene) {
     this.scene = scene as BaseScene;
     this.prefabs = {};
+
     this.entitiesById = {};
     this.entities = [];
   }
@@ -23,40 +24,10 @@ export class EntityManager {
     this.prefabs[key] = prefab;
   }
 
-  createPrefab(key: string, tiledProperties: any, depth: number = 0, x: number = 0, y: number = 0) {
-    const prefab = this.prefabs[key];
-    const entity = this.createEntity(prefab, tiledProperties, depth, x, y);
-
-    return entity;
-  }
-
-  getEntityById(id: string) {
-    return this.entitiesById[id];
-  }
-
-  getEntitiesByComponent(component: Phecs.ComponentConstructor) {
-    const entities = this.entities.filter(entity => {
-      return entity.components.some(entityComponent => {
-        return component.name === entityComponent.__proto__.constructor.name;
-      })
-    });
-
-    return entities;
-  }
-
-  destroy() {
-    this.entities.forEach(entity => {
-      entity.components.forEach(component => component.destroy());
-    });
-
-    this.entitiesById = {};
-    this.entities = [];
-  }
-
-  private createEntity(prefab: Phecs.Prefab, tiledProperties: any, depth: number = 0, x: number = 0, y: number = 0) {
+  createPrefab(type: string, tiledProperties: any, depth: number = 0, x: number = 0, y: number = 0) {
     const baseScene = this.scene as BaseScene;
-
-   const entity = new BaseEntity();
+    const entity = new BaseEntity(type);
+    const prefab = this.prefabs[type];
 
     const properties = {
       ...TiledUtil.normalizeProperties(tiledProperties)
@@ -80,4 +51,31 @@ export class EntityManager {
     return entity;
   }
 
+  getEntityById(id: string) {
+    return this.entitiesById[id];
+  }
+
+  // TODO: make this a util method
+  getEntitiesByComponent(component: Phecs.ComponentConstructor) {
+    const entities = this.entities.filter(entity => {
+      return entity.components.some(entityComponent => {
+        return component.name === entityComponent.__proto__.constructor.name;
+      })
+    });
+
+    return entities;
+  }
+
+  getEntitiesByType(type: string) {
+    return this.entities.filter(entity => entity.type === type);
+  }
+
+  destroy() {
+    this.entities.forEach(entity => {
+      entity.components.forEach(component => component.destroy());
+    });
+
+    this.entitiesById = {};
+    this.entities = [];
+  }
 }

--- a/src/lib/phecs/entity-manager.ts
+++ b/src/lib/phecs/entity-manager.ts
@@ -35,11 +35,13 @@ export class EntityManager {
   }
 
   getEntitiesByComponent(component: Phecs.ComponentConstructor) {
-    return this.entities.filter(entity => {
+    const entities = this.entities.filter(entity => {
       return entity.components.some(entityComponent => {
-        return typeof entityComponent === typeof component;
+        return component.name === entityComponent.__proto__.constructor.name;
       })
     });
+
+    return entities;
   }
 
   destroy() {
@@ -73,6 +75,7 @@ export class EntityManager {
     });
 
     this.entitiesById[entity.id] = entity;
+    this.entities.push(entity);
 
     return entity;
   }

--- a/src/lib/phecs/entity-manager.ts
+++ b/src/lib/phecs/entity-manager.ts
@@ -55,15 +55,10 @@ export class EntityManager {
     return this.entitiesById[id];
   }
 
-  // TODO: make this a util method
   getEntitiesByComponent(component: Phecs.ComponentConstructor) {
-    const entities = this.entities.filter(entity => {
-      return entity.components.some(entityComponent => {
-        return component.name === entityComponent.__proto__.constructor.name;
-      })
+    return this.entities.filter(entity => {
+      return entity.hasComponent(component);
     });
-
-    return entities;
   }
 
   getEntitiesByType(type: string) {

--- a/src/lib/phecs/entity-manager.ts
+++ b/src/lib/phecs/entity-manager.ts
@@ -34,7 +34,7 @@ export class EntityManager {
     return this.entitiesById[id];
   }
 
-  getEntitiesByComponent(component: Phecs.Component) {
+  getEntitiesByComponent(component: Phecs.ComponentConstructor) {
     return this.entities.filter(entity => {
       return entity.components.some(entityComponent => {
         return typeof entityComponent === typeof component;

--- a/src/plugins/area-manager-plugin.ts
+++ b/src/plugins/area-manager-plugin.ts
@@ -71,10 +71,10 @@ export class AreaManagerPlugin extends Phaser.Plugins.ScenePlugin {
 
   placeEntityAtMarker(entity: Phecs.Entity, markerName: string) {
     const marker = this.markers[markerName];
-    const sprite = entity.components[SpriteComponent.tag].sprite;
+    const sprite = entity.getComponent(SpriteComponent).sprite;
 
 
-    entity.components[SpriteComponent.tag].sprite.setPosition(marker.x, marker.y - sprite.height * sprite.originY);
+    entity.getComponent(SpriteComponent).sprite.setPosition(marker.x, marker.y - sprite.height * sprite.originY);
   }
 
   getTileLayer(name: string) {

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -41,6 +41,7 @@ import { PhiniteStateMachineComponent } from '../components/phinite-state-machin
 import { PhysicsBodyComponent } from '../components/physics-body-component';
 import { DoorComponent } from '../components/door-component';
 import { ShootsArrowsComponent } from '../components/shoots-arrows-component';
+import { SignComponent } from '../components/sign-component';
 import { SpriteComponent } from '../components/sprite-component';
 import { TextboxComponent } from '../components/textbox-component';
 import { ZoneBoundaryComponent } from '../components/zone-boundary-component';

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -185,7 +185,7 @@ export class ExplorationScene extends BaseScene {
 
         this.cameras.main.setBackgroundColor(0x888888);
         this.cameras.main.setBounds(0, 0, map.width * tileset.tileWidth, map.height * tileset.tileHeight);
-        this.cameras.main.startFollow(adventurer.components[SpriteComponent.tag].sprite, true);
+        this.cameras.main.startFollow(adventurer.getComponent(SpriteComponent).sprite, true);
 
         this.isLoadingArea = false;
         resolve();

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -68,6 +68,7 @@ export class ExplorationScene extends BaseScene {
     this.areaManager.registerArea('woollards-farm', 'woollards-farm', 'core-tileset', 'core-tileset');
     this.areaManager.registerArea('woollards-house', 'woollards-house', 'core-tileset', 'core-tileset');
 
+    /*
     this.phecs.phComponents.registerComponents(
       [
         { klass: AdventurerComponent, tag: AdventurerComponent.tag },
@@ -89,6 +90,7 @@ export class ExplorationScene extends BaseScene {
         { klass: ZoneBoundaryComponent, tag: ZoneBoundaryComponent.tag },
       ]
     );
+    */
 
     this.phecs.phSystems.registerSystems(
       [
@@ -145,7 +147,7 @@ export class ExplorationScene extends BaseScene {
         const map = this.areaManager.map;
         const tileset = this.areaManager.tileset;
 
-        const adventurer = this.phecs.phEntities.createPrefab('adventurer', {}, 2, 0, 0);
+        const adventurer = this.phecs.phEntities.createPrefab('adventurer', {}, 2);
         const mapProperties = TiledUtil.normalizeProperties(map.properties);
 
         if (markerName) {

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -27,24 +27,7 @@ import { sheepPrefab } from '../entities/sheep/prefab';
 import { signPrefab } from '../entities/sign/prefab';
 import { arrowPrefab } from '../entities/arrow/prefab';
 
-import { AdventurerComponent } from '../components/adventurer-component';
-import { AttachmentComponent } from '../components/attachment-component';
-import { BoundsComponent } from '../components/bounds-component';
-import { EnemyComponent } from '../components/enemy-component';
-import { HealthComponent } from '../components/health-component';
-import { HitboxComponent } from '../components/hitbox-component';
-import { HurtboxComponent } from '../components/hurtbox-component';
-import { IndicatorComponent } from '../components/indicator-component';
-import { InteractionCircleComponent } from '../components/interaction-circle-component';
-import { InvulnerabilityComponent } from '../components/invulnerability-component';
-import { PhiniteStateMachineComponent } from '../components/phinite-state-machine-component';
-import { PhysicsBodyComponent } from '../components/physics-body-component';
-import { DoorComponent } from '../components/door-component';
-import { ShootsArrowsComponent } from '../components/shoots-arrows-component';
-import { SignComponent } from '../components/sign-component';
 import { SpriteComponent } from '../components/sprite-component';
-import { TextboxComponent } from '../components/textbox-component';
-import { ZoneBoundaryComponent } from '../components/zone-boundary-component';
 
 import { TiledUtil } from '../utilities/tiled-util';
 
@@ -67,30 +50,6 @@ export class ExplorationScene extends BaseScene {
 
     this.areaManager.registerArea('woollards-farm', 'woollards-farm', 'core-tileset', 'core-tileset');
     this.areaManager.registerArea('woollards-house', 'woollards-house', 'core-tileset', 'core-tileset');
-
-    /*
-    this.phecs.phComponents.registerComponents(
-      [
-        { klass: AdventurerComponent, tag: AdventurerComponent.tag },
-        { klass: AttachmentComponent, tag: AttachmentComponent.tag },
-        { klass: BoundsComponent, tag: BoundsComponent.tag },
-        { klass: DoorComponent, tag: DoorComponent.tag },
-        { klass: EnemyComponent, tag: EnemyComponent.tag },
-        { klass: HealthComponent, tag: HealthComponent.tag },
-        { klass: HitboxComponent, tag: HitboxComponent.tag },
-        { klass: HurtboxComponent, tag: HurtboxComponent.tag },
-        { klass: IndicatorComponent, tag: IndicatorComponent.tag },
-        { klass: InteractionCircleComponent, tag: InteractionCircleComponent.tag },
-        { klass: InvulnerabilityComponent, tag: InvulnerabilityComponent.tag },
-        { klass: PhiniteStateMachineComponent, tag: PhiniteStateMachineComponent.tag },
-        { klass: PhysicsBodyComponent, tag: PhysicsBodyComponent.tag },
-        { klass: ShootsArrowsComponent, tag: ShootsArrowsComponent.tag },
-        { klass: SpriteComponent, tag: SpriteComponent.tag },
-        { klass: TextboxComponent, tag: TextboxComponent.tag },
-        { klass: ZoneBoundaryComponent, tag: ZoneBoundaryComponent.tag },
-      ]
-    );
-    */
 
     this.phecs.phSystems.registerSystems(
       [

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -164,11 +164,10 @@ export class ExplorationScene extends BaseScene {
         // Then I asked, why was it even working, setting up the colliders before the player
         // even shoots an arrow? It took me a little while to realize that the arrows were already
         // created at this point, due to the `ShootsArrowSystem#registerEntity` method.
-        /*
         if (mapProperties.entityLayerCollisions) {
           mapProperties.entityLayerCollisions.split(',').forEach((entityLayerPair: string) => {
             const [entityName, layerName] = entityLayerPair.split(':');
-            const entities = this.phecs.phEntities.getEntitiesByName(entityName);
+            const entities = this.phecs.phEntities.getEntitiesByType(entityName);
             const layer = this.areaManager.getTileLayer(layerName);
 
             if (layer == null) {
@@ -176,12 +175,11 @@ export class ExplorationScene extends BaseScene {
             }
 
             for (let entity of entities) {
-              const sprite = entity.components[SpriteComponent.tag].sprite;
+              const sprite = entity.getComponent(SpriteComponent).sprite;
               this.physics.add.collider(sprite, layer);
             }
           });
         }
-        */
 
         this.phecs.start();
 

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -164,6 +164,7 @@ export class ExplorationScene extends BaseScene {
         // Then I asked, why was it even working, setting up the colliders before the player
         // even shoots an arrow? It took me a little while to realize that the arrows were already
         // created at this point, due to the `ShootsArrowSystem#registerEntity` method.
+        /*
         if (mapProperties.entityLayerCollisions) {
           mapProperties.entityLayerCollisions.split(',').forEach((entityLayerPair: string) => {
             const [entityName, layerName] = entityLayerPair.split(':');
@@ -180,6 +181,7 @@ export class ExplorationScene extends BaseScene {
             }
           });
         }
+        */
 
         this.phecs.start();
 

--- a/src/scenes/prefab-test-scene.ts
+++ b/src/scenes/prefab-test-scene.ts
@@ -5,17 +5,6 @@ import { enemyPrefab } from '../entities/enemy/prefab';
 import { enemyStates } from '../entities/enemy/states';
 import { SpriteComponent } from '../components/sprite-component';
 import { PhysicsBodyComponent } from '../components/physics-body-component';
-import { AdventurerComponent } from '../components/adventurer-component';
-import { AttachmentComponent } from '../components/attachment-component';
-import { BoundsComponent } from '../components/bounds-component';
-import { DoorComponent } from '../components/door-component';
-import { HitboxComponent } from '../components/hitbox-component';
-import { HurtboxComponent } from '../components/hurtbox-component';
-import { IndicatorComponent } from '../components/indicator-component';
-import { InteractionCircleComponent } from '../components/interaction-circle-component';
-import { PhiniteStateMachineComponent } from '../components/phinite-state-machine-component';
-import { ShootsArrowsComponent } from '../components/shoots-arrows-component';
-import { TextboxComponent } from '../components/textbox-component';
 import { HasAttachmentsSystem } from '../systems/has-attachments-system';
 import { HasInteracionCircleSystem } from '../systems/has-interaction-circle-system';
 import { HasBoundsSystem } from '../systems/has-bounds-system';
@@ -37,23 +26,6 @@ export class PrefabTestScene extends BaseScene {
 
   create() {
     this.phecs.phEntities.registerPrefab('arrow', arrowPrefab);
-
-    this.phecs.phComponents.registerComponents(
-      [
-        { klass: AdventurerComponent, tag: AdventurerComponent.tag },
-        { klass: AttachmentComponent, tag: AttachmentComponent.tag },
-        { klass: BoundsComponent, tag: BoundsComponent.tag },
-        { klass: DoorComponent, tag: DoorComponent.tag },
-        { klass: HitboxComponent, tag: HitboxComponent.tag },
-        { klass: HurtboxComponent, tag: HurtboxComponent.tag },
-        { klass: IndicatorComponent, tag: IndicatorComponent.tag },
-        { klass: InteractionCircleComponent, tag: InteractionCircleComponent.tag },
-        { klass: PhysicsBodyComponent, tag: PhysicsBodyComponent.tag },
-        { klass: ShootsArrowsComponent, tag: ShootsArrowsComponent.tag },
-        { klass: SpriteComponent, tag: SpriteComponent.tag },
-        { klass: TextboxComponent, tag: TextboxComponent.tag },
-      ]
-    );
 
     this.phecs.phSystems.registerSystems(
       [

--- a/src/scenes/prefab-test-scene.ts
+++ b/src/scenes/prefab-test-scene.ts
@@ -76,13 +76,13 @@ export class PrefabTestScene extends BaseScene {
     const scale = 5;
     const enemy = this.phecs.phEntities.createPrefab('arrow', {}, scale, 0, 0);
 
-    enemy.components[SpriteComponent.tag].sprite.x = 150;
-    enemy.components[SpriteComponent.tag].sprite.y = 200;
-    enemy.components[SpriteComponent.tag].sprite.setFrame(frameIndex);
+    enemy.getComponent(SpriteComponent).sprite.x = 150;
+    enemy.getComponent(SpriteComponent).sprite.y = 200;
+    enemy.getComponent(SpriteComponent).sprite.setFrame(frameIndex);
 
-    enemy.components[PhysicsBodyComponent.tag].body.allowGravity = false;
+    enemy.getComponent(PhysicsBodyComponent).body.allowGravity = false;
 
-    enemy.components[SpriteComponent.tag].sprite.anims.stop();
+    enemy.getComponent(SpriteComponent).sprite.anims.stop();
 
     this.centerDebugCircle = this.add.circle(0, 0, 10, 0x00FF00);
     this.centerDebugCircle.setDepth(100);
@@ -97,7 +97,7 @@ export class PrefabTestScene extends BaseScene {
           break;
       }
 
-      enemy.components[SpriteComponent.tag].sprite.setFrame(frameIndex);
+      enemy.getComponent(SpriteComponent).sprite.setFrame(frameIndex);
       frameText.setText(`Frame ${frameIndex}`);
     });
 
@@ -114,12 +114,12 @@ export class PrefabTestScene extends BaseScene {
 
     this.input.keyboard.on(Phaser.Input.Keyboard.Events.ANY_KEY_DOWN, (e: { key: string; }) => {
       if (e.key === 'ArrowLeft') {
-        enemy.components[PhysicsBodyComponent.tag].body.acceleration.x = -600;
+        enemy.getComponent(PhysicsBodyComponent).body.acceleration.x = -600;
       } else if (e.key === 'ArrowRight') {
-        enemy.components[PhysicsBodyComponent.tag].body.acceleration.x = 600;
+        enemy.getComponent(PhysicsBodyComponent).body.acceleration.x = 600;
       } else if (e.key === ' ') {
-        enemy.components[PhysicsBodyComponent.tag].body.acceleration.x = 0;
-        enemy.components[PhysicsBodyComponent.tag].body.velocity.x = 0;
+        enemy.getComponent(PhysicsBodyComponent).body.acceleration.x = 0;
+        enemy.getComponent(PhysicsBodyComponent).body.velocity.x = 0;
       }
     });
 
@@ -133,7 +133,7 @@ export class PrefabTestScene extends BaseScene {
   }
 
   myUpdate() {
-    const center = this.enemy.components[SpriteComponent.tag].sprite.getCenter();
+    const center = this.enemy.getComponent(SpriteComponent).sprite.getCenter();
     this.centerDebugCircle.setPosition(center.x, center.y);
   }
 }

--- a/src/scenes/ui-scene.ts
+++ b/src/scenes/ui-scene.ts
@@ -1,6 +1,7 @@
 import 'phaser';
 import { BaseScene } from './base-scene';
 import { HealthComponent } from '../components/health-component';
+import { AdventurerComponent } from '../components/adventurer-component';
 
 const healthbarFrameMap: { [key: number]: number} = {
   5: 0,
@@ -19,9 +20,9 @@ export abstract class UiScene extends BaseScene {
     const healthbar = this.add.sprite(80, 25, 'healthbar', 0);
 
     const explorationScene = this.scene.get('exploration') as BaseScene;
-    const adventurer = explorationScene.phecs.phEntities.getEntitiesByTag('adventurer')[0];
+    const adventurer = explorationScene.phecs.phEntities.getEntitiesByComponent(AdventurerComponent)[0];
 
-    adventurer.components[HealthComponent.tag].onDamage((newHealth: number) => {
+    adventurer.getComponent(HealthComponent).onDamage((newHealth: number) => {
       healthbar.setFrame(healthbarFrameMap[newHealth]);
     });
   }

--- a/src/systems/adventurer-death-system.ts
+++ b/src/systems/adventurer-death-system.ts
@@ -11,9 +11,9 @@ export class AdventurerDeathSystem implements Phecs.System {
   }
 
   start(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
 
-    adventurer.components[HealthComponent.tag].onDeath(() => {
+    adventurer.getComponent(HealthComponent).onDeath(() => {
       this.scene.scene.stop('ui');
       this.scene.scene.stop('exploration');
       this.scene.scene.start('death');

--- a/src/systems/arrow-enemy-damage-system.ts
+++ b/src/systems/arrow-enemy-damage-system.ts
@@ -4,6 +4,8 @@ import { PhiniteStateMachineComponent } from '../components/phinite-state-machin
 import { HealthComponent } from '../components/health-component';
 
 import { BaseDamageSystem } from './base-damage-system';
+import { ArrowComponent } from '../components/arrow-component';
+import { EnemyComponent } from '../components/enemy-component';
 
 const ARROW_DAMAGE = 1;
 
@@ -12,21 +14,21 @@ export class ArrowEnemyDamageSystem extends BaseDamageSystem {
     super(
       {
         entityFetcher: phEntities => {
-          return phEntities.getEntitiesByName('arrow')
+          return phEntities.getEntitiesByComponent(ArrowComponent)
                            .filter(arrow => {
-                             const arrowState = arrow.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.currentState.id;
+                             const arrowState = arrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.currentState.id;
                              return arrowState === 'arrow-flying';
                            });
         },
         boxType: 'hitbox',
       },
       {
-        entityFetcher: phEntities => phEntities.getEntitiesByName('enemy'),
+        entityFetcher: phEntities => phEntities.getEntitiesByComponent(EnemyComponent),
         boxType: 'hurtbox',
       },
       (arrow: Phecs.Entity, enemy: Phecs.Entity) => {
-        arrow.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.doTransition({ to: 'arrow-disabled' });
-        enemy.components[HealthComponent.tag].decreaseHealth(ARROW_DAMAGE);
+        arrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.doTransition({ to: 'arrow-disabled' });
+        enemy.getComponent(HealthComponent).decreaseHealth(ARROW_DAMAGE);
       }
     );
   }

--- a/src/systems/arrow-enemy-damage-system.ts
+++ b/src/systems/arrow-enemy-damage-system.ts
@@ -4,7 +4,6 @@ import { PhiniteStateMachineComponent } from '../components/phinite-state-machin
 import { HealthComponent } from '../components/health-component';
 
 import { BaseDamageSystem } from './base-damage-system';
-import { ArrowComponent } from '../components/arrow-component';
 import { EnemyComponent } from '../components/enemy-component';
 
 const ARROW_DAMAGE = 1;
@@ -14,7 +13,7 @@ export class ArrowEnemyDamageSystem extends BaseDamageSystem {
     super(
       {
         entityFetcher: phEntities => {
-          return phEntities.getEntitiesByComponent(ArrowComponent)
+          return phEntities.getEntitiesByType('arrow')
                            .filter(arrow => {
                              const arrowState = arrow.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.currentState.id;
                              return arrowState === 'arrow-flying';

--- a/src/systems/base-damage-system.ts
+++ b/src/systems/base-damage-system.ts
@@ -25,12 +25,12 @@ export abstract class BaseDamageSystem implements Phecs.System {
     const entities2 = this.entities2Config.entityFetcher(phEntities);
 
     for (let entity1 of entities1) {
-      const entity1Boxes = entity1.components[AttachmentComponent.tag]
+      const entity1Boxes = entity1.getComponent(AttachmentComponent)
                                             .getAttachmentsByType(this.entities1Config.boxType)
                                             .filter((hurtbox: Attachment) => hurtbox.isEnabled())
 
       for (let entity2 of entities2) {
-        const entity2Boxes = entity2.components[AttachmentComponent.tag]
+        const entity2Boxes = entity2.getComponent(AttachmentComponent)
                                   .getAttachmentsByType(this.entities2Config.boxType)
                                   .filter((hitbox: Attachment) => hitbox.isEnabled())
 

--- a/src/systems/door-system.ts
+++ b/src/systems/door-system.ts
@@ -4,7 +4,6 @@ import { AdventurerComponent } from '../components/adventurer-component';
 import { IndicatorComponent } from '../components/indicator-component';
 import { InteractionCircleComponent } from '../components/interaction-circle-component';
 import { EntityManager } from '../lib/phecs/entity-manager';
-import { SignComponent } from '../components/sign-component';
 
 export class DoorSystem implements Phecs.System {
   private scene: ExplorationScene;
@@ -36,7 +35,7 @@ export class DoorSystem implements Phecs.System {
 
   stop(phEntities: EntityManager) {
     const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
-    const doors = phEntities.getEntitiesByComponent(SignComponent);
+    const doors = phEntities.getEntitiesByComponent(DoorComponent);
 
     const controlKeys = new Set(doors.map(door => adventurer.getComponent(AdventurerComponent).controls[door.getComponent(InteractionCircleComponent).interactionControl]));
 

--- a/src/systems/door-system.ts
+++ b/src/systems/door-system.ts
@@ -4,6 +4,7 @@ import { AdventurerComponent } from '../components/adventurer-component';
 import { IndicatorComponent } from '../components/indicator-component';
 import { InteractionCircleComponent } from '../components/interaction-circle-component';
 import { EntityManager } from '../lib/phecs/entity-manager';
+import { SignComponent } from '../components/sign-component';
 
 export class DoorSystem implements Phecs.System {
   private scene: ExplorationScene;
@@ -15,16 +16,16 @@ export class DoorSystem implements Phecs.System {
   }
 
   start(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
-    const doors = phEntities.getEntitiesByName(DoorComponent.tag);
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const doors = phEntities.getEntitiesByComponent(DoorComponent);
 
     doors.forEach(door => {
-      const controlKey = adventurer.components[AdventurerComponent.tag].controls[door.components[InteractionCircleComponent.tag].interactionControl];
+      const controlKey = adventurer.getComponent(AdventurerComponent).controls[door.getComponent(InteractionCircleComponent).interactionControl];
 
       const listener = () => {
-        const activeInteractionIds = door.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('active');
+        const activeInteractionIds = door.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
         if (activeInteractionIds.includes(adventurer.id)) {
-          this.scene.loadNewArea(door.components[DoorComponent.tag].toAreaKey, door.components[DoorComponent.tag].toMarker);
+          this.scene.loadNewArea(door.getComponent(DoorComponent).toAreaKey, door.getComponent(DoorComponent).toMarker);
         }
       };
 
@@ -34,10 +35,10 @@ export class DoorSystem implements Phecs.System {
   }
 
   stop(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
-    const doors = phEntities.getEntitiesByTag('sign');
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const doors = phEntities.getEntitiesByComponent(SignComponent);
 
-    const controlKeys = new Set(doors.map(door => adventurer.components[AdventurerComponent.tag].controls[door.components[InteractionCircleComponent.tag].interactionControl]));
+    const controlKeys = new Set(doors.map(door => adventurer.getComponent(AdventurerComponent).controls[door.getComponent(InteractionCircleComponent).interactionControl]));
 
     this.listeners.forEach(listener => {
       controlKeys.forEach(controlKey => {
@@ -49,19 +50,19 @@ export class DoorSystem implements Phecs.System {
   }
 
   update(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
-    const doors = phEntities.getEntitiesByName(DoorComponent.tag);
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const doors = phEntities.getEntitiesByComponent(DoorComponent);
 
-    const enteringDoorIds = adventurer.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('entering');
+    const enteringDoorIds = adventurer.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('entering');
     const enteringDoors = doors.filter(door => enteringDoorIds.includes(door.id));
     for (let enteringDoor of enteringDoors) {
-      enteringDoor.components[IndicatorComponent.tag].showIndicator();
+      enteringDoor.getComponent(IndicatorComponent).showIndicator();
     }
 
-    const exitingDoorIds = adventurer.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('exiting');
+    const exitingDoorIds = adventurer.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('exiting');
     const exitingDoors = doors.filter(door => exitingDoorIds.includes(door.id));
     for (let enteringDoor of exitingDoors) {
-      enteringDoor.components[IndicatorComponent.tag].hideIndicator();
+      enteringDoor.getComponent(IndicatorComponent).hideIndicator();
     }
   }
 }

--- a/src/systems/enemy-adventurer-damage-system.ts
+++ b/src/systems/enemy-adventurer-damage-system.ts
@@ -12,20 +12,20 @@ export class EnemyAdventurerDamageSystem extends BaseDamageSystem {
     super(
       {
         entityFetcher: phEntities => {
-          return phEntities.getEntitiesByTag(AdventurerComponent.tag)
+          return phEntities.getEntitiesByComponent(AdventurerComponent)
           .filter((adventurer: Phecs.Entity) => {
-            return !adventurer.components[InvulnerabilityComponent.tag].isInvulnerable;
+            return !adventurer.getComponent(InvulnerabilityComponent).isInvulnerable;
           });
         },
         boxType: 'hurtbox'
       },
       {
-        entityFetcher: phEntities => phEntities.getEntitiesByTag(EnemyComponent.tag),
+        entityFetcher: phEntities => phEntities.getEntitiesByComponent(EnemyComponent),
         boxType: 'hurtbox',
       },
       (adventurer: Phecs.Entity, enemy: Phecs.Entity) => {
-        adventurer.components[InvulnerabilityComponent.tag].makeInvulnerable();
-        adventurer.components[HealthComponent.tag].decreaseHealth(ENEMY_DAMAGE);
+        adventurer.getComponent(InvulnerabilityComponent).makeInvulnerable();
+        adventurer.getComponent(HealthComponent).decreaseHealth(ENEMY_DAMAGE);
       }
     )
   }

--- a/src/systems/has-attachments-system.ts
+++ b/src/systems/has-attachments-system.ts
@@ -4,11 +4,11 @@ import { EntityManager } from '../lib/phecs/entity-manager';
 
 export class HasAttachmentsSystem implements Phecs.System {
   update(phEntities: EntityManager) {
-    const entities = phEntities.getEntitiesByTag(AttachmentComponent.tag);
+    const entities = phEntities.getEntitiesByComponent(AttachmentComponent);
 
     for (let entity of entities) {
-      for (let attachment of entity.components[AttachmentComponent.tag].attachments) {
-        attachment.syncToSprite(entity.components[SpriteComponent.tag].sprite);
+      for (let attachment of entity.getComponent(AttachmentComponent).attachments) {
+        attachment.syncToSprite(entity.getComponent(SpriteComponent).sprite);
       }
     }
   }

--- a/src/systems/has-bounds-system.ts
+++ b/src/systems/has-bounds-system.ts
@@ -6,13 +6,13 @@ import { EntityManager } from '../lib/phecs/entity-manager';
 
 export class HasBoundsSystem implements Phecs.System {
   update(phEntities: EntityManager) {
-    const entities = phEntities.getEntitiesByTag(BoundsComponent.tag);
+    const entities = phEntities.getEntitiesByComponent(BoundsComponent);
 
     entities.forEach(entity => {
-      const key = entity.components[SpriteComponent.tag].sprite.frame.texture.key;
-      const frame = entity.components[SpriteComponent.tag].sprite.frame.name;
+      const key = entity.getComponent(SpriteComponent).sprite.frame.texture.key;
+      const frame = entity.getComponent(SpriteComponent).sprite.frame.name;
 
-      const boundsFrame: Systems.HasBounds.Frame = entity.components[BoundsComponent.tag].boundsFrames.find((b: Systems.HasBounds.Frame) => b.key === key && b.frame === frame) as Systems.HasBounds.Frame;
+      const boundsFrame: Systems.HasBounds.Frame = entity.getComponent(BoundsComponent).boundsFrames.find((b: Systems.HasBounds.Frame) => b.key === key && b.frame === frame) as Systems.HasBounds.Frame;
       if (boundsFrame) {
         const bounds: Systems.HasBounds.Bounds = boundsFrame.bounds;
 
@@ -20,28 +20,28 @@ export class HasBoundsSystem implements Phecs.System {
           x: bounds.offset.x,
           y: bounds.offset.y,
         }
-        if (entity.components[SpriteComponent.tag].sprite.flipX) {
-          offset.x = entity.components[SpriteComponent.tag].sprite.width - bounds.offset.x - bounds.size.width;
+        if (entity.getComponent(SpriteComponent).sprite.flipX) {
+          offset.x = entity.getComponent(SpriteComponent).sprite.width - bounds.offset.x - bounds.size.width;
         }
-        if (entity.components[SpriteComponent.tag].sprite.flipY) {
-          offset.y = entity.components[SpriteComponent.tag].sprite.height - bounds.offset.y - bounds.size.height;
+        if (entity.getComponent(SpriteComponent).sprite.flipY) {
+          offset.y = entity.getComponent(SpriteComponent).sprite.height - bounds.offset.y - bounds.size.height;
         }
 
         // I have no idea why this needs the `scale` part, but it does
         const rotationPoint = {
-          x: entity.components[SpriteComponent.tag].sprite.displayWidth * entity.components[SpriteComponent.tag].sprite.originX / entity.components[SpriteComponent.tag].sprite.scale,
-          y: entity.components[SpriteComponent.tag].sprite.displayHeight * entity.components[SpriteComponent.tag].sprite.originY / entity.components[SpriteComponent.tag].sprite.scale,
+          x: entity.getComponent(SpriteComponent).sprite.displayWidth * entity.getComponent(SpriteComponent).sprite.originX / entity.getComponent(SpriteComponent).sprite.scale,
+          y: entity.getComponent(SpriteComponent).sprite.displayHeight * entity.getComponent(SpriteComponent).sprite.originY / entity.getComponent(SpriteComponent).sprite.scale,
         }
-        Phaser.Math.RotateAround(offset, rotationPoint.x, rotationPoint.y, entity.components[SpriteComponent.tag].sprite.rotation);
+        Phaser.Math.RotateAround(offset, rotationPoint.x, rotationPoint.y, entity.getComponent(SpriteComponent).sprite.rotation);
 
-        entity.components[PhysicsBodyComponent.tag].body.setSize(bounds.size.width, bounds.size.height);
-        entity.components[PhysicsBodyComponent.tag].body.setOffset(offset.x, offset.y);
+        entity.getComponent(PhysicsBodyComponent).body.setSize(bounds.size.width, bounds.size.height);
+        entity.getComponent(PhysicsBodyComponent).body.setOffset(offset.x, offset.y);
       } else {
-        entity.components[PhysicsBodyComponent.tag].body.setSize(entity.components[SpriteComponent.tag].sprite.width, entity.components[SpriteComponent.tag].sprite.height);
-        entity.components[PhysicsBodyComponent.tag].body.setOffset(0, 0);
+        entity.getComponent(PhysicsBodyComponent).body.setSize(entity.getComponent(SpriteComponent).sprite.width, entity.getComponent(SpriteComponent).sprite.height);
+        entity.getComponent(PhysicsBodyComponent).body.setOffset(0, 0);
       }
 
-      entity.components[PhysicsBodyComponent.tag].body.updateBounds();
+      entity.getComponent(PhysicsBodyComponent).body.updateBounds();
     });
   }
 }

--- a/src/systems/has-controls-system.ts
+++ b/src/systems/has-controls-system.ts
@@ -4,10 +4,10 @@ import { EntityManager } from '../lib/phecs/entity-manager';
 
 export class HasControlsSystem implements Phecs.System {
   stop(phEntities: EntityManager) {
-    const entities = phEntities.getEntitiesByTag(AdventurerComponent.tag);
+    const entities = phEntities.getEntitiesByComponent(AdventurerComponent);
 
     entities.forEach(entity => {
-      Object.values(entity.components[AdventurerComponent.tag].controls).forEach((key) => {
+      Object.values(entity.getComponent(AdventurerComponent).controls).forEach((key) => {
         (key as Phaser.Input.Keyboard.Key).removeAllListeners();
       });
     });

--- a/src/systems/has-hitboxes-system.ts
+++ b/src/systems/has-hitboxes-system.ts
@@ -7,19 +7,19 @@ import { EntityManager } from '../lib/phecs/entity-manager';
 
 export class HasHitboxesSystem implements Phecs.System {
   update(phEntities: EntityManager) {
-    const entities = phEntities.getEntitiesByTag(HitboxComponent.tag)
+    const entities = phEntities.getEntitiesByComponent(HitboxComponent)
       .filter(entity => {
-        return entity.components[HitboxComponent.tag].enabled;
+        return entity.getComponent(HitboxComponent).enabled;
       });
 
     entities.forEach(entity => {
-      const textureKey = entity.components[SpriteComponent.tag].sprite.frame.texture.key;
-      const frameName = entity.components[SpriteComponent.tag].sprite.frame.name;
+      const textureKey = entity.getComponent(SpriteComponent).sprite.frame.texture.key;
+      const frameName = entity.getComponent(SpriteComponent).sprite.frame.name;
 
-      const hitboxFrame: Systems.HasHitboxes.Frame = entity.components[HitboxComponent.tag].hitboxFrames.find((f: Systems.HasHitboxes.Frame) => f.key === textureKey && f.frame === frameName) as Systems.HasHitboxes.Frame;
+      const hitboxFrame: Systems.HasHitboxes.Frame = entity.getComponent(HitboxComponent).hitboxFrames.find((f: Systems.HasHitboxes.Frame) => f.key === textureKey && f.frame === frameName) as Systems.HasHitboxes.Frame;
 
       if (hitboxFrame && hitboxFrame.hitboxes) {
-        const attachments = entity.components[AttachmentComponent.tag].getAttachmentsByType('hitbox');
+        const attachments = entity.getComponent(AttachmentComponent).getAttachmentsByType('hitbox');
 
         for (let i = 0; i < attachments.length; i++) {
           const hitbox = hitboxFrame.hitboxes[i];

--- a/src/systems/has-hurtboxes-system.ts
+++ b/src/systems/has-hurtboxes-system.ts
@@ -7,19 +7,19 @@ import { AttachmentComponent } from '../components/attachment-component';
 
 export class HasHurtboxesSystem implements Phecs.System {
   update(phEntities: EntityManager) {
-    const entities = phEntities.getEntitiesByTag(HurtboxComponent.tag)
+    const entities = phEntities.getEntitiesByComponent(HurtboxComponent)
       .filter(entity => {
-        return entity.components[HurtboxComponent.tag].enabled;
+        return entity.getComponent(HurtboxComponent).enabled;
       });
 
     entities.forEach(entity => {
-      const textureKey = entity.components[SpriteComponent.tag].sprite.frame.texture.key;
-      const frameName = entity.components[SpriteComponent.tag].sprite.frame.name;
+      const textureKey = entity.getComponent(SpriteComponent).sprite.frame.texture.key;
+      const frameName = entity.getComponent(SpriteComponent).sprite.frame.name;
 
-      const hurtboxFrame: Systems.HasHurtboxes.Frame = entity.components[HurtboxComponent.tag].hurtboxFrames.find((f: Systems.HasHurtboxes.Frame) => f.key === textureKey && f.frame === frameName) as Systems.HasHurtboxes.Frame;
+      const hurtboxFrame: Systems.HasHurtboxes.Frame = entity.getComponent(HurtboxComponent).hurtboxFrames.find((f: Systems.HasHurtboxes.Frame) => f.key === textureKey && f.frame === frameName) as Systems.HasHurtboxes.Frame;
 
       if (hurtboxFrame && hurtboxFrame.hurtboxes) {
-        const attachments = entity.components[AttachmentComponent.tag].getAttachmentsByType('hurtbox');
+        const attachments = entity.getComponent(AttachmentComponent).getAttachmentsByType('hurtbox');
 
         for (let i = 0; i < attachments.length; i++) {
           const hurtbox = hurtboxFrame.hurtboxes[i];

--- a/src/systems/has-interaction-circle-system.ts
+++ b/src/systems/has-interaction-circle-system.ts
@@ -11,30 +11,28 @@ export class HasInteracionCircleSystem implements Phecs.System {
   }
 
   update(phEntities: EntityManager) {
-    const entities: Phecs.Entity[] = phEntities.getEntitiesByTag(InteractionCircleComponent.tag);
+    const entities: Phecs.Entity[] = phEntities.getEntitiesByComponent(InteractionCircleComponent);
 
     for (let entity of entities) {
-      entity.components[InteractionCircleComponent.tag].interactionCircle.setPosition(entity.components[SpriteComponent.tag].sprite.x, entity.components[SpriteComponent.tag].sprite.y);
+      entity.getComponent(InteractionCircleComponent).interactionCircle.setPosition(entity.getComponent(SpriteComponent).sprite.x, entity.getComponent(SpriteComponent).sprite.y);
 
-      if (entity.components[InteractionCircleComponent.tag].debugInteractionCircle) {
+      const debugInteractionCircle = entity.getComponent(InteractionCircleComponent).debugInteractionCircle;
+      if (debugInteractionCircle) {
         const position = this.scene.input.activePointer.positionToCamera(this.scene.cameras.main) as { x: number, y: number };
-        entity.components[InteractionCircleComponent.tag].debugInteractionCircle.setPosition(entity.components[SpriteComponent.tag].sprite.x, entity.components[SpriteComponent.tag].sprite.y);
+        debugInteractionCircle.setPosition(entity.getComponent(SpriteComponent).sprite.x, entity.getComponent(SpriteComponent).sprite.y);
 
-        if (Phaser.Geom.Intersects.CircleToCircle(entity.components[InteractionCircleComponent.tag].interactionCircle, new Phaser.Geom.Circle(position.x, position.y, 1))) {
-          entity.components[InteractionCircleComponent.tag].debugInteractionCircle.setFillStyle(0xFF0000, 0.5);
+        if (Phaser.Geom.Intersects.CircleToCircle(entity.getComponent(InteractionCircleComponent).interactionCircle, new Phaser.Geom.Circle(position.x, position.y, 1))) {
+          debugInteractionCircle.setFillStyle(0xFF0000, 0.5);
         } else {
-          entity.components[InteractionCircleComponent.tag].debugInteractionCircle.setFillStyle(0x00FF00, 0.5);
+          debugInteractionCircle.setFillStyle(0x00FF00, 0.5);
         }
       }
     };
 
-    /*
-      * entering -> active -> exiting
-    */
     for (let entity of entities) {
       const intersectingEntityIds = this.getIntersectingInteractionIds(entity, entities);
 
-      entity.components[InteractionCircleComponent.tag].interactionTracker.update(intersectingEntityIds);
+      entity.getComponent(InteractionCircleComponent).interactionTracker.update(intersectingEntityIds);
     };
   }
 
@@ -42,8 +40,8 @@ export class HasInteracionCircleSystem implements Phecs.System {
     return allEntities
       .filter(otherEntity => otherEntity.id !== entity.id)
       .filter(otherEntity => {
-        const circle1 = entity.components[InteractionCircleComponent.tag].interactionCircle;
-        const circle2 = otherEntity.components[InteractionCircleComponent.tag].interactionCircle;
+        const circle1 = entity.getComponent(InteractionCircleComponent).interactionCircle;
+        const circle2 = otherEntity.getComponent(InteractionCircleComponent).interactionCircle;
 
         return Phaser.Geom.Intersects.CircleToCircle(circle1, circle2);
       })

--- a/src/systems/has-phinite-state-machine-system.ts
+++ b/src/systems/has-phinite-state-machine-system.ts
@@ -5,10 +5,10 @@ import { EntityManager } from '../lib/phecs/entity-manager';
 
 export class HasPhiniteStateMachineSystem implements Phecs.System {
   update(phEntities: EntityManager) {
-    const entities = phEntities.getEntitiesByTag(PhiniteStateMachineComponent.tag)
+    const entities = phEntities.getEntitiesByComponent(PhiniteStateMachineComponent)
 
     entities.forEach(entity => {
-      entity.components[PhiniteStateMachineComponent.tag].phiniteStateMachine.update();
+      entity.getComponent(PhiniteStateMachineComponent).phiniteStateMachine.update();
     });
   }
 }

--- a/src/systems/sign-system.ts
+++ b/src/systems/sign-system.ts
@@ -3,7 +3,6 @@ import { AdventurerComponent } from '../components/adventurer-component';
 import { InteractionCircleComponent } from '../components/interaction-circle-component';
 import { TextboxComponent } from '../components/textbox-component';
 import { EntityManager } from '../lib/phecs/entity-manager';
-import { SignComponent } from '../components/sign-component';
 
 export class SignSystem implements Phecs.System {
   private listeners: (() => void)[];
@@ -14,7 +13,7 @@ export class SignSystem implements Phecs.System {
 
   start(phEntities: EntityManager) {
     const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
-    const signs = phEntities.getEntitiesByComponent(SignComponent);
+    const signs = phEntities.getEntitiesByType('sign');
 
     signs.forEach(sign => {
       const controlKey = adventurer.getComponent(AdventurerComponent).controls[sign.getComponent(InteractionCircleComponent).interactionControl];
@@ -37,7 +36,7 @@ export class SignSystem implements Phecs.System {
 
   stop(phEntities: EntityManager) {
     const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
-    const signs = phEntities.getEntitiesByComponent(SignComponent);
+    const signs = phEntities.getEntitiesByType('sign');
 
     const controlKeys = new Set(signs.map(sign => adventurer.getComponent(AdventurerComponent).controls[sign.getComponent(InteractionCircleComponent).interactionControl]));
 
@@ -52,7 +51,7 @@ export class SignSystem implements Phecs.System {
 
   update(phEntities: EntityManager) {
     const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
-    const signs = phEntities.getEntitiesByComponent(SignComponent);
+    const signs = phEntities.getEntitiesByType('sign');
 
     const enteringSignIds = adventurer.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('entering');
     const enteringSigns = signs.filter(sign => enteringSignIds.includes(sign.id));

--- a/src/systems/sign-system.ts
+++ b/src/systems/sign-system.ts
@@ -3,6 +3,7 @@ import { AdventurerComponent } from '../components/adventurer-component';
 import { InteractionCircleComponent } from '../components/interaction-circle-component';
 import { TextboxComponent } from '../components/textbox-component';
 import { EntityManager } from '../lib/phecs/entity-manager';
+import { SignComponent } from '../components/sign-component';
 
 export class SignSystem implements Phecs.System {
   private listeners: (() => void)[];
@@ -12,19 +13,19 @@ export class SignSystem implements Phecs.System {
   }
 
   start(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
-    const signs = phEntities.getEntitiesByTag('sign');
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const signs = phEntities.getEntitiesByComponent(SignComponent);
 
     signs.forEach(sign => {
-      const controlKey = adventurer.components[AdventurerComponent.tag].controls[sign.components[InteractionCircleComponent.tag].interactionControl];
+      const controlKey = adventurer.getComponent(AdventurerComponent).controls[sign.getComponent(InteractionCircleComponent).interactionControl];
 
       const listener = () => {
-        const activeInteractionIds = sign.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('active');
+        const activeInteractionIds = sign.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('active');
         if (activeInteractionIds.includes(adventurer.id)) {
-          if (sign.components[TextboxComponent.tag].isTextboxShowing) {
-            sign.components[TextboxComponent.tag].hideTextbox();
+          if (sign.getComponent(TextboxComponent).isTextboxShowing) {
+            sign.getComponent(TextboxComponent).hideTextbox();
           } else {
-            sign.components[TextboxComponent.tag].showTextbox();
+            sign.getComponent(TextboxComponent).showTextbox();
           }
         }
       };
@@ -35,10 +36,10 @@ export class SignSystem implements Phecs.System {
   }
 
   stop(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
-    const signs = phEntities.getEntitiesByTag('sign');
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const signs = phEntities.getEntitiesByComponent(SignComponent);
 
-    const controlKeys = new Set(signs.map(sign => adventurer.components[AdventurerComponent.tag].controls[sign.components[InteractionCircleComponent.tag].interactionControl]));
+    const controlKeys = new Set(signs.map(sign => adventurer.getComponent(AdventurerComponent).controls[sign.getComponent(InteractionCircleComponent).interactionControl]));
 
     this.listeners.forEach(listener => {
       controlKeys.forEach(controlKey => {
@@ -50,22 +51,22 @@ export class SignSystem implements Phecs.System {
   }
 
   update(phEntities: EntityManager) {
-    const adventurer = phEntities.getEntitiesByTag(AdventurerComponent.tag)[0];
-    const signs = phEntities.getEntitiesByTag('sign');
+    const adventurer = phEntities.getEntitiesByComponent(AdventurerComponent)[0];
+    const signs = phEntities.getEntitiesByComponent(SignComponent);
 
-    const enteringSignIds = adventurer.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('entering');
+    const enteringSignIds = adventurer.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('entering');
     const enteringSigns = signs.filter(sign => enteringSignIds.includes(sign.id));
     for (let enteringSign of enteringSigns) {
-      enteringSign.components[IndicatorComponent.tag].showIndicator();
+      enteringSign.getComponent(IndicatorComponent).showIndicator();
     }
 
-    const exitingSignIds = adventurer.components[InteractionCircleComponent.tag].interactionTracker.getEntityIds('exiting');
+    const exitingSignIds = adventurer.getComponent(InteractionCircleComponent).interactionTracker.getEntityIds('exiting');
     const exitingSigns = signs.filter(sign => exitingSignIds.includes(sign.id));
     for (let exitingSign of exitingSigns) {
-      exitingSign.components[IndicatorComponent.tag].hideIndicator();
+      exitingSign.getComponent(IndicatorComponent).hideIndicator();
 
-      if (exitingSign.components[TextboxComponent.tag].isTextboxShowing) {
-        exitingSign.components[TextboxComponent.tag].hideTextbox();
+      if (exitingSign.getComponent(TextboxComponent).isTextboxShowing) {
+        exitingSign.getComponent(TextboxComponent).hideTextbox();
       }
     }
   }


### PR DESCRIPTION
Holy shit, this is so much nicer. Now prefabs are defined as a list of components - with their component class and its data.

I also got rid of all the tags in each component, and you now use `entity.getComponent(AdventurerComponent)` to get a component, which preserves the type information!

Same kind of thing for the `EntityManager`, its got a `getEntitiesByComponent` that will return entities now rather than getting them by their tag.