### PR TITLE
Background music

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { NinePatchPlugin } from '@koreez/phaser3-ninepatch';
 
 import { AreaManagerPlugin } from './plugins/area-manager-plugin';
 import { ControlsPlugin } from './plugins/controls/controls-plugin';
+import { MusicPlugin } from './plugins/music-plugin';
 import { ParallaxSpritePlugin } from './plugins/parallax-sprite-plugin';
 import { PersistencePlugin } from './plugins/persistence-plugin';
 import { PhecsPlugin } from './plugins/phecs-plugin';
@@ -31,6 +32,11 @@ const gameConfig = {
         key: 'Phecs',
         plugin: PhecsPlugin,
         mapping: 'phecs',
+      },
+      {
+        key: 'Music',
+        plugin: MusicPlugin,
+        mapping: 'music',
       },
       {
         key: 'Controls',

--- a/src/lib/phecs/systems-manager.ts
+++ b/src/lib/phecs/systems-manager.ts
@@ -48,14 +48,12 @@ export class SystemsManager {
   }
 
   registerSystems(systemsList: Phecs.SystemConstructor[]) {
-    console.log('registering systems', systemsList)
     systemsList.forEach((klass) => {
       this.systems.push(new klass(this.scene));
     });
   }
 
   removeSystems(systemsList: Phecs.SystemConstructor[]) {
-    console.log('removing systems', systemsList);
     const systemsToRemove = this.systems.filter(system => systemsList.some(klass => system instanceof klass));
 
     systemsToRemove.forEach(system => {

--- a/src/lib/phecs/systems-manager.ts
+++ b/src/lib/phecs/systems-manager.ts
@@ -48,8 +48,21 @@ export class SystemsManager {
   }
 
   registerSystems(systemsList: Phecs.SystemConstructor[]) {
+    console.log('registering systems', systemsList)
     systemsList.forEach((klass) => {
       this.systems.push(new klass(this.scene));
     });
+  }
+
+  removeSystems(systemsList: Phecs.SystemConstructor[]) {
+    console.log('removing systems', systemsList);
+    const systemsToRemove = this.systems.filter(system => systemsList.some(klass => system instanceof klass));
+
+    systemsToRemove.forEach(system => {
+      if (system.stop) system.stop(this.scene.phecs.phEntities);
+      if (system.destroy) system.destroy();
+    });
+
+    this.systems = this.systems.filter(system => !systemsToRemove.includes(system));
   }
 }

--- a/src/plugins/music-plugin.ts
+++ b/src/plugins/music-plugin.ts
@@ -2,31 +2,32 @@ import { SCENE_KEYS } from "../constants/scene-keys";
 import { MusicRegistrar } from "../registrars/music-registrar";
 
 export class MusicPlugin extends Phaser.Plugins.ScenePlugin {
-  private currentArea: string;
-  private areaMusic: Record<string, Phaser.Sound.BaseSound>;
+  private currentMusicKey: string;
+  private keyedMusic: Record<string, Phaser.Sound.BaseSound>;
 
   constructor(scene: Phaser.Scene, pluginManager: Phaser.Plugins.PluginManager) {
     super(scene, pluginManager);
 
-    this.currentArea = '';
-    this.areaMusic = {};
+    this.currentMusicKey = '';
+    this.keyedMusic = {};
   }
 
   playForArea(areaKey: string) {
-    if (MusicRegistrar.getMusicForArea(this.currentArea) === MusicRegistrar.getMusicForArea(areaKey)) {
+    const newAreaMusicKey = MusicRegistrar.getMusicForArea(areaKey);
+    if (this.currentMusicKey === newAreaMusicKey) {
       return;
     }
 
-    if (this.currentArea) {
-      this.areaMusic[this.currentArea].stop();
+    if (this.currentMusicKey) {
+      this.keyedMusic[this.currentMusicKey].stop();
     }
 
-    this.currentArea = areaKey;
-
-    if (!this.areaMusic[this.currentArea]) {
-      this.areaMusic[this.currentArea] = this.scene.sound.add(MusicRegistrar.getMusicForArea(this.currentArea), { loop: true });
+    if (!this.keyedMusic[newAreaMusicKey]) {
+      this.keyedMusic[newAreaMusicKey] = this.scene.sound.add(newAreaMusicKey, { loop: true });
     }
 
-    this.areaMusic[this.currentArea].play();
+    this.keyedMusic[newAreaMusicKey].play();
+
+    this.currentMusicKey = newAreaMusicKey;
   }
 }

--- a/src/plugins/music-plugin.ts
+++ b/src/plugins/music-plugin.ts
@@ -19,14 +19,29 @@ export class MusicPlugin extends Phaser.Plugins.ScenePlugin {
     }
 
     if (this.currentMusicKey) {
-      this.keyedMusic[this.currentMusicKey].stop();
+      this.scene.tweens.add({
+        targets: this.keyedMusic[this.currentMusicKey],
+        props: {
+          volume: { getStart: () => 1, getEnd: () => 0 }
+        },
+        onComplete: () => {
+          this.keyedMusic[this.currentMusicKey].stop();
+        }
+      });
     }
 
     if (!this.keyedMusic[newAreaMusicKey]) {
       this.keyedMusic[newAreaMusicKey] = this.scene.sound.add(newAreaMusicKey, { loop: true });
     }
 
-    this.keyedMusic[newAreaMusicKey].play();
+    const music = this.keyedMusic[newAreaMusicKey];
+    music.play();
+    this.scene.tweens.add({
+      targets: music,
+      props: {
+        volume: { getStart: () => 0, getEnd: () => 1 }
+      }
+    });
 
     this.currentMusicKey = newAreaMusicKey;
   }

--- a/src/plugins/music-plugin.ts
+++ b/src/plugins/music-plugin.ts
@@ -1,0 +1,32 @@
+import { SCENE_KEYS } from "../constants/scene-keys";
+import { MusicRegistrar } from "../registrars/music-registrar";
+
+export class MusicPlugin extends Phaser.Plugins.ScenePlugin {
+  private currentArea: string;
+  private areaMusic: Record<string, Phaser.Sound.BaseSound>;
+
+  constructor(scene: Phaser.Scene, pluginManager: Phaser.Plugins.PluginManager) {
+    super(scene, pluginManager);
+
+    this.currentArea = '';
+    this.areaMusic = {};
+  }
+
+  playForArea(areaKey: string) {
+    if (MusicRegistrar.getMusicForArea(this.currentArea) === MusicRegistrar.getMusicForArea(areaKey)) {
+      return;
+    }
+
+    if (this.currentArea) {
+      this.areaMusic[this.currentArea].stop();
+    }
+
+    this.currentArea = areaKey;
+
+    if (!this.areaMusic[this.currentArea]) {
+      this.areaMusic[this.currentArea] = this.scene.sound.add(MusicRegistrar.getMusicForArea(this.currentArea), { loop: true });
+    }
+
+    this.areaMusic[this.currentArea].play();
+  }
+}

--- a/src/registrars/music-registrar.ts
+++ b/src/registrars/music-registrar.ts
@@ -1,0 +1,11 @@
+const areaMusic: Record<string, string> = {
+  'woollards-farm': 'farm',
+  'woollards-house': 'farm',
+  'forest': 'forest'
+};
+
+export const MusicRegistrar = {
+  getMusicForArea(areaKey: string) {
+    return areaMusic[areaKey];
+  }
+}

--- a/src/registrars/system-registrar.ts
+++ b/src/registrars/system-registrar.ts
@@ -29,7 +29,11 @@ const areaSystems: Record<string, SystemConfig[]> = {
 };
 
 export const SystemRegistrar = {
-  getSystemsForArea(areaKey: string, progression: ProgressionDocument) {
+  getSystemsForArea(areaKey: string) {
+    return areaSystems[areaKey].map(systemConfig => systemConfig.system);
+  },
+
+  getFilteredSystemsForArea(areaKey: string, progression: ProgressionDocument) {
     const systems = areaSystems[areaKey];
 
     return systems.filter(systemConfig => {

--- a/src/scenes/base-scene.ts
+++ b/src/scenes/base-scene.ts
@@ -4,10 +4,12 @@ import { AreaManagerPlugin } from '../plugins/area-manager-plugin';
 import { PhecsPlugin } from '../plugins/phecs-plugin';
 import { PersistencePlugin } from '../plugins/persistence-plugin';
 import { ControlsPlugin } from '../plugins/controls/controls-plugin';
+import { MusicPlugin } from '../plugins/music-plugin';
 
 export abstract class BaseScene extends Phaser.Scene {
   phecs!: PhecsPlugin;
   areaManager!: AreaManagerPlugin;
   persistence!: PersistencePlugin;
   controls!: ControlsPlugin;
+  music!: MusicPlugin;
 }

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -34,6 +34,7 @@ import { TiledUtil } from '../utilities/tiled-util';
 import { SCENE_KEYS } from '../constants/scene-keys';
 import { DepthManager } from '../lib/depth-manager';
 import { SystemRegistrar } from '../registrars/system-registrar';
+import { MusicRegistrar } from '../registrars/music-registrar';
 
 const baseSystems = [
   HasAttachmentsSystem,
@@ -55,6 +56,7 @@ const baseSystems = [
 
 export class ExplorationScene extends BaseScene {
   private isLoadingArea: boolean;
+  private backgroundMusic?: Phaser.Sound.BaseSound;
 
   constructor() {
     super({ key: SCENE_KEYS.exploration });
@@ -159,6 +161,16 @@ export class ExplorationScene extends BaseScene {
         });
     });
 
+    this.backgroundMusic = this.sound.add(MusicRegistrar.getMusicForArea(areaKey), { loop: true });
+    this.backgroundMusic.volume = 0;
+    this.backgroundMusic.play();
+    this.tweens.add({
+      targets: this.backgroundMusic,
+      props: {
+        volume: 1
+      },
+    });
+
     this.controls.start();
     this.phecs.start();
 
@@ -168,15 +180,19 @@ export class ExplorationScene extends BaseScene {
     if (markerName) this.persistence.location.markerName = markerName;
     this.persistence.save();
 
-    this.isLoadingArea = false;
-
     var { x, y, width, height } = this.calculateCameraBounds(map, tileset);
     this.cameras.main.setBounds(x, y, width, height);
     this.cameras.main.startFollow(adventurer.getComponent(SpriteComponent).sprite, true);
     this.cameras.main.fadeIn(300);
+
+    this.isLoadingArea = false;
   }
 
   private shutdown() {
+    if (this.backgroundMusic) {
+      this.backgroundMusic.stop();
+      this.backgroundMusic.destroy();
+    }
     this.phecs.shutdown();
     this.areaManager.unload();
   }

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -69,20 +69,11 @@ export class ExplorationScene extends BaseScene {
   }
 
   create(data: any) {
-    this.registerSystems(data.areaKey);
+    this.phecs.phSystems.registerSystems(baseSystems);
     this.registerPrefabs();
 
-    this.loadNewArea(data.areaKey, data.markerName)
+    this.transferToArea(data.areaKey, data.markerName)
     this.scene.launch(SCENE_KEYS.hud);
-  }
-
-  registerSystems(areaKey: string) {
-    this.phecs.phSystems.registerSystems(
-      [
-        ...baseSystems,
-        ...SystemRegistrar.getSystemsForArea(areaKey, this.persistence.progression)
-      ]
-    );
   }
 
   registerPrefabs() {
@@ -103,64 +94,99 @@ export class ExplorationScene extends BaseScene {
       this.isLoadingArea = true;
     }
 
-    // This delayed call is because when entities get destroyed, their event listeners will still be called for that tick of the game loop.
-    // The events must be queued up or something in the event emitter, and even when all the events are cleared,
-    // the listeners still get called.
-    // This manifested as a problem when you entered a door and the sign interaction check got called for the
-    // previous scene.
-    this.time.delayedCall(0, () => {
-      this.cameras.main.fadeOut(300, 0, 0, 0, (camera: Phaser.Cameras.Scene2D.Camera, progress: number) => {
-        if (progress === 1) {
-          this.controls.stop();
-          this.phecs.reset();
-          this.areaManager.unload();
-          this.scene.restart({ areaKey, markerName });
-        }
-      });
+    this.cameras.main.fadeOut(0);
+    this.loadNewArea(areaKey, markerName).then(() => {
+      this.cameras.main.fadeIn(1000);
     });
   }
 
   private loadNewArea(areaKey: string, markerName?: string) {
-    this.areaManager.load(areaKey);
+    return new Promise((resolve, reject) => {
+      // This delayed call is because when entities get destroyed, their event listeners will still be called for that tick of the game loop.
+      // The events must be queued up or something in the event emitter, and even when all the events are cleared,
+      // the listeners still get called.
+      // This manifested as a problem when you entered a door and the sign interaction check got called for the
+      // previous scene.
+      this.time.delayedCall(0, () => {
+        this.cameras.main.fadeOut(300, 0, 0, 0, (camera: Phaser.Cameras.Scene2D.Camera, progress: number) => {
+          if (progress === 1) {
+            this.controls.stop();
+            this.phecs.reset();
+            if (this.areaManager.currentAreaKey) {
+              this.phecs.phSystems.removeSystems(SystemRegistrar.getSystemsForArea(this.areaManager.currentAreaKey));
+            }
+            this.areaManager.unload();
+            
+            this.areaManager.load(areaKey);
+            this.phecs.phSystems.registerSystems(SystemRegistrar.getFilteredSystemsForArea(areaKey, this.persistence.progression));
 
-    const map = this.areaManager.map;
-    const tileset = this.areaManager.tileset;
+            const map = this.areaManager.map;
+            const tileset = this.areaManager.tileset;
+        
+            const adventurer = this.phecs.phEntities.createPrefab('adventurer', {}, DepthManager.depthFor('adventurer'));
+            const mapProperties = TiledUtil.normalizeProperties(map.properties);
 
-    const adventurer = this.phecs.phEntities.createPrefab('adventurer', {}, DepthManager.depthFor('adventurer'));
-    const mapProperties = TiledUtil.normalizeProperties(map.properties);
+            if (markerName) {
+              this.areaManager.placeEntityAtMarker(adventurer, markerName);
+            } else if (mapProperties.startingMarker) {
+              this.areaManager.placeEntityAtMarker(adventurer, mapProperties.startingMarker);
+            }
 
-    if (markerName) {
-      this.areaManager.placeEntityAtMarker(adventurer, markerName);
-    } else if (mapProperties.startingMarker) {
-      this.areaManager.placeEntityAtMarker(adventurer, mapProperties.startingMarker);
-    }
+            // At one point, I had a question about why arrows were colliding with tilemap layers.
+            // I wasn't explicitly setting up that collider anywhere.
+            // Turns out, the colliders were getting created because of the entry of `arrow:ground`
+            // in the map properties.
+            //
+            // Then I asked, why was it even working, setting up the colliders before the player
+            // even shoots an arrow? It took me a little while to realize that the arrows were already
+            // created at this point, due to the `ShootsArrowSystem#registerEntity` method.
+            const collisionMap = this.areaManager.getCollisionMap();
+            Object.entries(collisionMap).forEach(([entityType, layerNames]) => {
+              layerNames
+                .forEach(layerName => {
+                  const entities = this.phecs.phEntities.getEntities(entityType);
+                  const layer = this.areaManager.getTileLayer(layerName);
 
-    // At one point, I had a question about why arrows were colliding with tilemap layers.
-    // I wasn't explicitly setting up that collider anywhere.
-    // Turns out, the colliders were getting created because of the entry of `arrow:ground`
-    // in the map properties.
-    //
-    // Then I asked, why was it even working, setting up the colliders before the player
-    // even shoots an arrow? It took me a little while to realize that the arrows were already
-    // created at this point, due to the `ShootsArrowSystem#registerEntity` method.
-    const collisionMap = this.areaManager.getCollisionMap();
-    Object.entries(collisionMap).forEach(([entityType, layerNames]) => {
-      layerNames
-        .forEach(layerName => {
-          const entities = this.phecs.phEntities.getEntities(entityType);
-          const layer = this.areaManager.getTileLayer(layerName);
+                  if (layer == null) {
+                    throw new Error(`Layer does not exist for collision map: ${layerName}`);
+                  }
 
-          if (layer == null) {
-            throw new Error(`Layer does not exist for collision map: ${layerName}`);
-          }
+                  for (let entity of entities) {
+                    const sprite = entity.getComponent(SpriteComponent).sprite;
+                    this.physics.add.collider(sprite, layer);
+                  }
+                });
+            });
 
-          for (let entity of entities) {
-            const sprite = entity.getComponent(SpriteComponent).sprite;
-            this.physics.add.collider(sprite, layer);
+            this.controls.start();
+            this.phecs.start();
+
+            this.physics.world.setBounds(0, 0, map.width * tileset.tileWidth, map.height * tileset.tileHeight);
+
+            this.persistence.location.areaKey = areaKey;
+            if (markerName) this.persistence.location.markerName = markerName;
+            this.persistence.save();
+
+            var { x, y, width, height } = this.calculateCameraBounds(map, tileset);
+            this.cameras.main.setBounds(x, y, width, height);
+            this.cameras.main.startFollow(adventurer.getComponent(SpriteComponent).sprite, true);
+            this.cameras.main.fadeIn(300);
+
+            this.isLoadingArea = false;
+
+            resolve();
           }
         });
+      });
     });
 
+
+
+
+
+   
+
+    /*
     this.backgroundMusic = this.sound.add(MusicRegistrar.getMusicForArea(areaKey), { loop: true });
     this.backgroundMusic.volume = 0;
     this.backgroundMusic.play();
@@ -170,22 +196,9 @@ export class ExplorationScene extends BaseScene {
         volume: 1
       },
     });
+    */
 
-    this.controls.start();
-    this.phecs.start();
-
-    this.physics.world.setBounds(0, 0, map.width * tileset.tileWidth, map.height * tileset.tileHeight);
-
-    this.persistence.location.areaKey = areaKey;
-    if (markerName) this.persistence.location.markerName = markerName;
-    this.persistence.save();
-
-    var { x, y, width, height } = this.calculateCameraBounds(map, tileset);
-    this.cameras.main.setBounds(x, y, width, height);
-    this.cameras.main.startFollow(adventurer.getComponent(SpriteComponent).sprite, true);
-    this.cameras.main.fadeIn(300);
-
-    this.isLoadingArea = false;
+    
   }
 
   private shutdown() {

--- a/src/scenes/exploration-scene.ts
+++ b/src/scenes/exploration-scene.ts
@@ -6,7 +6,6 @@ import { AreaTransferSystem } from '../systems/area-transfer-system';
 import { ArrowEnemyDamageSystem } from '../systems/arrow-enemy-damage-system';
 import { AdventurerDeathSystem } from '../systems/adventurer-death-system';
 import { AdventurerDoorSystem } from '../systems/adventurer-door-system';
-import { AdventurerKnightSystem } from '../systems/adventurer-knight-system';
 import { AdventurerNpcSystem } from '../systems/adventurer-npc-system';
 import { AdventurerSignSystem } from '../systems/adventurer-sign-system';
 import { EnemyAdventurerDamageSystem } from '../systems/enemy-adventurer-damage-system';
@@ -16,8 +15,6 @@ import { HasHitboxesSystem } from '../systems/has-hitboxes-system';
 import { HasHurtboxesSystem } from '../systems/has-hurtboxes-system';
 import { HasPhiniteStateMachineSystem } from '../systems/has-phinite-state-machine-system';
 import { InteractionComponentSystem } from '../systems/interaction-component-system';
-import { KnightForestCustceneSystem } from '../systems/knight-forest-cutscene-system';
-import { SheepGateSystem } from '../systems/sheep-gate-system';
 
 import { adventurerPrefab } from '../entities/adventurer/prefab';
 import { arrowPrefab } from '../entities/arrow/prefab';
@@ -34,7 +31,6 @@ import { TiledUtil } from '../utilities/tiled-util';
 import { SCENE_KEYS } from '../constants/scene-keys';
 import { DepthManager } from '../lib/depth-manager';
 import { SystemRegistrar } from '../registrars/system-registrar';
-import { MusicRegistrar } from '../registrars/music-registrar';
 
 const baseSystems = [
   HasAttachmentsSystem,
@@ -95,9 +91,7 @@ export class ExplorationScene extends BaseScene {
     }
 
     this.cameras.main.fadeOut(0);
-    this.loadNewArea(areaKey, markerName).then(() => {
-      this.cameras.main.fadeIn(1000);
-    });
+    this.loadNewArea(areaKey, markerName);
   }
 
   private loadNewArea(areaKey: string, markerName?: string) {
@@ -172,6 +166,8 @@ export class ExplorationScene extends BaseScene {
             this.cameras.main.startFollow(adventurer.getComponent(SpriteComponent).sprite, true);
             this.cameras.main.fadeIn(300);
 
+            this.music.playForArea(areaKey);
+
             this.isLoadingArea = false;
 
             resolve();
@@ -179,26 +175,6 @@ export class ExplorationScene extends BaseScene {
         });
       });
     });
-
-
-
-
-
-   
-
-    /*
-    this.backgroundMusic = this.sound.add(MusicRegistrar.getMusicForArea(areaKey), { loop: true });
-    this.backgroundMusic.volume = 0;
-    this.backgroundMusic.play();
-    this.tweens.add({
-      targets: this.backgroundMusic,
-      props: {
-        volume: 1
-      },
-    });
-    */
-
-    
   }
 
   private shutdown() {

--- a/src/scenes/preload-scene.ts
+++ b/src/scenes/preload-scene.ts
@@ -7,6 +7,10 @@ export class PreloadScene extends BaseScene {
   }
 
   preload() {
+    // music
+    this.load.audio('farm', ['assets/music/farm.ogg', 'assets/music/farm.mp3']);
+    this.load.audio('forest', ['assets/music/forest.ogg', 'assets/music/forest.mp3']);
+
     // title screen backgounrd
     this.load.image('title-screen', 'assets/backgrounds/title-screen.png');
     this.load.image('vignette-effect', 'assets/backgrounds/vignette-effect.png');


### PR DESCRIPTION
* Makes area loading happen in-scene again (it was changed to happen on scene restart in #31). This required unloading area specific systems when unloading an area, and loading them when entering a new area.
* Adds a `music` plugin to handle fading in/out background music when loading new areas. This doesn't necessarily need to be a plugin since its really only ever used by the `ExplorationScene`, but maybe it'll evolve into a sound effects plugin in the future.